### PR TITLE
Fixes #119. Added an exception when is updating around redstone to ig…

### DIFF
--- a/src/main/java/cn/nukkit/level/Level.java
+++ b/src/main/java/cn/nukkit/level/Level.java
@@ -1238,7 +1238,7 @@ public class Level implements ChunkManager, Metadatable {
 
     public void updateAroundRedstone(Vector3 pos, BlockFace face) {
         for (BlockFace side : BlockFace.values()) {
-            if (face != null && side == face) {
+            if (face != null && side == face || getBlock(pos) instanceof BlockPistonBase) {
                 continue;
             }
 


### PR DESCRIPTION
…nore if Block is intanceof BlockPistonBase

The issue originally begin from 
~~~~~~
BlockRedstoneDiode:onUpdate -> else if (!this.isPowered) {
-> this.level.updateAroundRedstone...
}