### PR TITLE
Replicate Area Effect Cloud and Lingering potion fixes to V1.X

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,7 @@ Click the link above to see the future.
 ### Added
 - This change log file
 - [#108] EntityMoveByPistonEvent
+- [#140] `isUndead()` method to the entities
 
 ### Fixes
 - [#129] A typo in the BlockBambooSapling class name **(breaking change)**
@@ -25,6 +26,8 @@ Click the link above to see the future.
 - [#129] Fixes a turtle_egg placement validation
 - [#129] Campfire can no longer be placed over an other campfire directly
 - [#129] The sound that campfire does when it extinguishes
+- [#140] Instant damage and instant health are now inverted when applied to undead entities
+- [#140] A collision detection issue on Area Effect Cloud which could make it wears off way quicker than it should
 
 ### Changed
 - Make BlockLectern implements Faceable
@@ -160,3 +163,4 @@ Click the link above to see the future.
 [#102]: https://github.com/GameModsBR/PowerNukkit/pull/102
 [#108]: https://github.com/GameModsBR/PowerNukkit/pull/108
 [#129]: https://github.com/GameModsBR/PowerNukkit/pull/108
+[#140]: https://github.com/GameModsBR/PowerNukkit/pull/108

--- a/src/main/java/cn/nukkit/entity/Entity.java
+++ b/src/main/java/cn/nukkit/entity/Entity.java
@@ -2403,6 +2403,10 @@ public abstract class Entity extends Location implements Metadatable {
         return server;
     }
 
+    public boolean isUndead() {
+        return false;
+    }
+
     @Override
     public boolean equals(Object obj) {
         if (obj == null) {

--- a/src/main/java/cn/nukkit/entity/mob/EntityDrowned.java
+++ b/src/main/java/cn/nukkit/entity/mob/EntityDrowned.java
@@ -46,4 +46,9 @@ public class EntityDrowned extends EntityMob implements EntitySmite {
     public Item[] getDrops() {
         return new Item[]{Item.get(Item.ROTTEN_FLESH)};
     }
+
+    @Override
+    public boolean isUndead() {
+        return true;
+    }
 }

--- a/src/main/java/cn/nukkit/entity/mob/EntityHusk.java
+++ b/src/main/java/cn/nukkit/entity/mob/EntityHusk.java
@@ -40,4 +40,9 @@ public class EntityHusk extends EntityMob implements EntitySmite {
     public String getName() {
         return "Husk";
     }
+
+    @Override
+    public boolean isUndead() {
+        return true;
+    }
 }

--- a/src/main/java/cn/nukkit/entity/mob/EntityPhantom.java
+++ b/src/main/java/cn/nukkit/entity/mob/EntityPhantom.java
@@ -46,4 +46,9 @@ public class EntityPhantom extends EntityMob implements EntitySmite {
     public Item[] getDrops() {
         return new Item[]{Item.get(470)};
     }
+
+    @Override
+    public boolean isUndead() {
+        return true;
+    }
 }

--- a/src/main/java/cn/nukkit/entity/mob/EntitySkeleton.java
+++ b/src/main/java/cn/nukkit/entity/mob/EntitySkeleton.java
@@ -46,4 +46,9 @@ public class EntitySkeleton extends EntityMob implements EntitySmite {
     public Item[] getDrops() {
         return new Item[]{Item.get(Item.BONE, Item.ARROW)};
     }
+
+    @Override
+    public boolean isUndead() {
+        return true;
+    }
 }

--- a/src/main/java/cn/nukkit/entity/mob/EntityStray.java
+++ b/src/main/java/cn/nukkit/entity/mob/EntityStray.java
@@ -46,4 +46,9 @@ public class EntityStray extends EntityMob implements EntitySmite {
     public Item[] getDrops() {
         return new Item[]{Item.get(Item.BONE, Item.ARROW)};
     }
+
+    @Override
+    public boolean isUndead() {
+        return true;
+    }
 }

--- a/src/main/java/cn/nukkit/entity/mob/EntityWither.java
+++ b/src/main/java/cn/nukkit/entity/mob/EntityWither.java
@@ -40,4 +40,9 @@ public class EntityWither extends EntityMob implements EntitySmite {
     public String getName() {
         return "Wither";
     }
+
+    @Override
+    public boolean isUndead() {
+        return true;
+    }
 }

--- a/src/main/java/cn/nukkit/entity/mob/EntityWitherSkeleton.java
+++ b/src/main/java/cn/nukkit/entity/mob/EntityWitherSkeleton.java
@@ -39,4 +39,9 @@ public class EntityWitherSkeleton extends EntityMob implements EntitySmite {
     public String getName() {
         return "WitherSkeleton";
     }
+
+    @Override
+    public boolean isUndead() {
+        return true;
+    }
 }

--- a/src/main/java/cn/nukkit/entity/mob/EntityZombie.java
+++ b/src/main/java/cn/nukkit/entity/mob/EntityZombie.java
@@ -40,4 +40,9 @@ public class EntityZombie extends EntityMob implements EntitySmite {
     public String getName() {
         return "Zombie";
     }
+
+    @Override
+    public boolean isUndead() {
+        return true;
+    }
 }

--- a/src/main/java/cn/nukkit/entity/mob/EntityZombiePigman.java
+++ b/src/main/java/cn/nukkit/entity/mob/EntityZombiePigman.java
@@ -40,4 +40,9 @@ public class EntityZombiePigman extends EntityMob implements EntitySmite {
     public String getName() {
         return "ZombiePigman";
     }
+
+    @Override
+    public boolean isUndead() {
+        return true;
+    }
 }

--- a/src/main/java/cn/nukkit/entity/mob/EntityZombieVillager.java
+++ b/src/main/java/cn/nukkit/entity/mob/EntityZombieVillager.java
@@ -37,4 +37,9 @@ public class EntityZombieVillager extends EntityMob implements EntitySmite {
     public String getName() {
         return "Zombie Villager";
     }
+
+    @Override
+    public boolean isUndead() {
+        return true;
+    }
 }

--- a/src/main/java/cn/nukkit/entity/mob/EntityZombieVillagerV1.java
+++ b/src/main/java/cn/nukkit/entity/mob/EntityZombieVillagerV1.java
@@ -40,4 +40,9 @@ public class EntityZombieVillagerV1 extends EntityMob implements EntitySmite {
     public String getName() {
         return "Zombie Villager";
     }
+
+    @Override
+    public boolean isUndead() {
+        return true;
+    }
 }

--- a/src/main/java/cn/nukkit/entity/passive/EntitySkeletonHorse.java
+++ b/src/main/java/cn/nukkit/entity/passive/EntitySkeletonHorse.java
@@ -41,4 +41,9 @@ public class EntitySkeletonHorse extends EntityAnimal implements EntitySmite {
     public Item[] getDrops() {
         return new Item[]{Item.get(Item.BONE)};
     }
+
+    @Override
+    public boolean isUndead() {
+        return true;
+    }
 }

--- a/src/main/java/cn/nukkit/entity/passive/EntityZombieHorse.java
+++ b/src/main/java/cn/nukkit/entity/passive/EntityZombieHorse.java
@@ -41,4 +41,9 @@ public class EntityZombieHorse extends EntityAnimal implements EntitySmite {
     public Item[] getDrops() {
         return new Item[]{Item.get(Item.ROTTEN_FLESH, 1, 1)};
     }
+
+    @Override
+    public boolean isUndead() {
+        return true;
+    }
 }

--- a/src/main/java/cn/nukkit/potion/Potion.java
+++ b/src/main/java/cn/nukkit/potion/Potion.java
@@ -199,11 +199,17 @@ public class Potion implements Cloneable {
         switch (this.getId()) {
             case INSTANT_HEALTH:
             case INSTANT_HEALTH_II:
-                entity.heal(new EntityRegainHealthEvent(entity, (float) (health * (double) (4 << (applyEffect.getAmplifier() + 1))), EntityRegainHealthEvent.CAUSE_MAGIC));
+                if (entity.isUndead())
+                    entity.attack(new EntityDamageEvent(entity, DamageCause.MAGIC, (float) (health * (double) (6 << (applyEffect.getAmplifier() + 1)))));
+                else
+                    entity.heal(new EntityRegainHealthEvent(entity, (float) (health * (double) (4 << (applyEffect.getAmplifier() + 1))), EntityRegainHealthEvent.CAUSE_MAGIC));
                 break;
             case HARMING:
             case HARMING_II:
-                entity.attack(new EntityDamageEvent(entity, DamageCause.MAGIC, (float) (health * (double) (6 << (applyEffect.getAmplifier() + 1)))));
+                if (entity.isUndead())
+                    entity.heal(new EntityRegainHealthEvent(entity, (float) (health * (double) (4 << (applyEffect.getAmplifier() + 1))), EntityRegainHealthEvent.CAUSE_MAGIC));
+                else
+                    entity.attack(new EntityDamageEvent(entity, DamageCause.MAGIC, (float) (health * (double) (6 << (applyEffect.getAmplifier() + 1)))));
                 break;
             default:
                 int duration = (int) ((isSplash() ? health : 1) * (double) applyEffect.getDuration() + 0.5);


### PR DESCRIPTION
Replicate #131 and #132 to V1.X. Fixes #130

adds isUndead() and inverts potion effects when it's true

Fixes AreaEffectCloud collision rules.

Note: I had no time to test, it was pretty late here, if somebody could test I that would be great :)