### PR TITLE
Fixes the blue_ice blast resistance in v1.x

### DIFF
--- a/src/main/java/cn/nukkit/block/BlockBlueIce.java
+++ b/src/main/java/cn/nukkit/block/BlockBlueIce.java
@@ -24,7 +24,12 @@ public class BlockBlueIce extends BlockIcePacked {
     public double getHardness() {
         return 2.8;
     }
-    
+
+    @Override
+    public double getResistance() {
+        return 14;
+    }
+
     @Override
     public boolean isTransparent() {
         return false;


### PR DESCRIPTION
Changes it from `2.5` to `14` as in #143 