### PR TITLE
[1.2.0] Fixes anvil not merging enchanted items correctly

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,7 +14,7 @@ Click the link above to see the future.
   This should be used **only by developers** to debug the server without interruptions by the crash detection system.
 
 ### Fixes
-- [#222] Anvil not merging enchanted items correctly and destroying the items.
+- [#224] Anvil not merging enchanted items correctly and destroying the items.
 
 ## [1.2.0.0-PN] - 2020-05-03 ([Check the milestone](https://github.com/GameModsBR/PowerNukkit/milestone/6?closed=1))
 **Note:** Effort has been made to keep this list accurate but some bufixes and new features might be missing here, specially those made by the NukkitX team and contributors.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,13 @@ Nukkit 1.X and 2.X.
 ## [Unreleased]
 Click the link above to see the future.
 
+### Added
+- [#224] Added option to disable watchdog with `-DdisableWatchdog=true`. 
+  This should be used **only by developers** to debug the server without interruptions by the crash detection system.
+
+### Fixes
+- [#222] Anvil not merging enchanted items correctly and destroying the items.
+
 ## [1.2.0.0-PN] - 2020-05-03 ([Check the milestone](https://github.com/GameModsBR/PowerNukkit/milestone/6?closed=1))
 **Note:** Effort has been made to keep this list accurate but some bufixes and new features might be missing here, specially those made by the NukkitX team and contributors.
 
@@ -174,9 +181,11 @@ Click the link above to see the future.
 [#93]: https://github.com/GameModsBR/PowerNukkit/issues/93
 [#102]: https://github.com/GameModsBR/PowerNukkit/pull/102
 [#108]: https://github.com/GameModsBR/PowerNukkit/pull/108
-[#129]: https://github.com/GameModsBR/PowerNukkit/pull/108
-[#140]: https://github.com/GameModsBR/PowerNukkit/pull/108
+[#129]: https://github.com/GameModsBR/PowerNukkit/pull/129
+[#140]: https://github.com/GameModsBR/PowerNukkit/pull/140
 [#152]: https://github.com/GameModsBR/PowerNukkit/pull/152
 [#170]: https://github.com/GameModsBR/PowerNukkit/pull/170
 [#210]: https://github.com/GameModsBR/PowerNukkit/issues/210
-[#219]: https://github.com/GameModsBR/PowerNukkit/pull/170
+[#219]: https://github.com/GameModsBR/PowerNukkit/pull/219
+[#222]: https://github.com/GameModsBR/PowerNukkit/issues/223
+[#224]: https://github.com/GameModsBR/PowerNukkit/pull/224

--- a/src/main/java/cn/nukkit/Server.java
+++ b/src/main/java/cn/nukkit/Server.java
@@ -573,7 +573,7 @@ public class Server {
 
         this.enablePlugins(PluginLoadOrder.POSTWORLD);
 
-        if (Nukkit.DEBUG < 2) {
+        if (Nukkit.DEBUG < 2 || !Boolean.parseBoolean(System.getProperty("disableWatchdog", "false"))) {
             this.watchdog = new Watchdog(this, 60000);
             this.watchdog.start();
         }

--- a/src/main/java/cn/nukkit/Server.java
+++ b/src/main/java/cn/nukkit/Server.java
@@ -573,7 +573,7 @@ public class Server {
 
         this.enablePlugins(PluginLoadOrder.POSTWORLD);
 
-        if (Nukkit.DEBUG < 2 || !Boolean.parseBoolean(System.getProperty("disableWatchdog", "false"))) {
+        if (Nukkit.DEBUG < 2 && !Boolean.parseBoolean(System.getProperty("disableWatchdog", "false"))) {
             this.watchdog = new Watchdog(this, 60000);
             this.watchdog.start();
         }

--- a/src/main/java/cn/nukkit/inventory/AnvilInventory.java
+++ b/src/main/java/cn/nukkit/inventory/AnvilInventory.java
@@ -141,7 +141,7 @@ public class AnvilInventory extends FakeBlockUIComponent {
             
                     while(targetEnchIter.hasNext()) {
                         Enchantment targetEnchantment = targetEnchIter.next();
-                        if (targetEnchantment != sacrificeEnchantment && (!sacrificeEnchantment.isCompatibleWith(targetEnchantment) || !targetEnchantment.isCompatibleWith(sacrificeEnchantment))) {
+                        if (targetEnchantment.type != sacrificeEnchantment.type && (!sacrificeEnchantment.isCompatibleWith(targetEnchantment) || !targetEnchantment.isCompatibleWith(sacrificeEnchantment))) {
                             compatible = false;
                             ++extraCost;
                         }


### PR DESCRIPTION
Fixes:
https://youtu.be/1j1LlaCtGpE

Also makes possible to disable the watchdog using the system parameter: `-DdisableWatchdog=true`.

Example:

```bash
java -DdisableWatchdog=true -Xmx4G -jar PowerNukkit.jar
```

Related to #222 and #225 