### PR TITLE
PN-87 Fix #228 Invalid enchantment order on anvil's results

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,6 +15,7 @@ Click the link above to see the future.
 
 ### Fixes
 - [#224] Anvil not merging enchanted items correctly and destroying the items.
+- [#228] Invalid enchantment order on anvil's results causing the crafting transaction to fail. 
 
 ## [1.2.0.0-PN] - 2020-05-03 ([Check the milestone](https://github.com/GameModsBR/PowerNukkit/milestone/6?closed=1))
 **Note:** Effort has been made to keep this list accurate but some bufixes and new features might be missing here, specially those made by the NukkitX team and contributors.
@@ -189,3 +190,4 @@ Click the link above to see the future.
 [#219]: https://github.com/GameModsBR/PowerNukkit/pull/219
 [#222]: https://github.com/GameModsBR/PowerNukkit/issues/223
 [#224]: https://github.com/GameModsBR/PowerNukkit/pull/224
+[#228]: https://github.com/GameModsBR/PowerNukkit/issues/228

--- a/src/main/java/cn/nukkit/inventory/AnvilInventory.java
+++ b/src/main/java/cn/nukkit/inventory/AnvilInventory.java
@@ -9,8 +9,8 @@ import cn.nukkit.nbt.tag.CompoundTag;
 import io.netty.util.internal.StringUtil;
 
 import java.util.Arrays;
-import java.util.HashMap;
 import java.util.Iterator;
+import java.util.LinkedHashMap;
 import java.util.Map;
 import java.util.stream.Stream;
 
@@ -60,7 +60,7 @@ public class AnvilInventory extends FakeBlockUIComponent {
         int repairMaterial = getRepairMaterial(target);
         Item result = target.clone();
         int levelCost = getRepairCost(result) + (sacrifice.isNull() ? 0 : getRepairCost(sacrifice));
-        Map<Integer, Enchantment> enchantmentMap = new HashMap<>();
+        Map<Integer, Enchantment> enchantmentMap = new LinkedHashMap<>();
         for (Enchantment enchantment : target.getEnchantments()) {
             enchantmentMap.put(enchantment.getId(), enchantment);
         }


### PR DESCRIPTION
The order must match the client otherwise the transaction fails.

Fix #228 