### PR TITLE
Cost calculation not applying bedrock edition reduction

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,7 +15,8 @@ Click the link above to see the future.
 
 ### Fixes
 - [#224] Anvil not merging enchanted items correctly and destroying the items.
-- [#228] Invalid enchantment order on anvil's results causing the crafting transaction to fail. 
+- [#228] Invalid enchantment order on anvil's results causing the crafting transaction to fail.
+- [#226] Anvil cost calculation not applying bedrock edition reductions
 
 ## [1.2.0.0-PN] - 2020-05-03 ([Check the milestone](https://github.com/GameModsBR/PowerNukkit/milestone/6?closed=1))
 **Note:** Effort has been made to keep this list accurate but some bufixes and new features might be missing here, specially those made by the NukkitX team and contributors.
@@ -190,4 +191,5 @@ Click the link above to see the future.
 [#219]: https://github.com/GameModsBR/PowerNukkit/pull/219
 [#222]: https://github.com/GameModsBR/PowerNukkit/issues/223
 [#224]: https://github.com/GameModsBR/PowerNukkit/pull/224
+[#226]: https://github.com/GameModsBR/PowerNukkit/issues/226
 [#228]: https://github.com/GameModsBR/PowerNukkit/issues/228

--- a/src/main/java/cn/nukkit/inventory/AnvilInventory.java
+++ b/src/main/java/cn/nukkit/inventory/AnvilInventory.java
@@ -117,7 +117,7 @@ public class AnvilInventory extends FakeBlockUIComponent {
                     Enchantment sacrificeEnchantment;
                     do {
                         if (!sacrificeEnchIter.hasNext()) {
-                            if (incompatibleFlag && !compatibleFlag) {
+                            if (incompatibleFlag && !compatibleFlag) { // TODO These flags would never be positive?
                                 setResult(Item.get(0));
                                 setLevelCost(0);
                                 return;
@@ -172,7 +172,7 @@ public class AnvilInventory extends FakeBlockUIComponent {
                             rarity = Math.max(1, rarity / 2);
                         }
                 
-                        extraCost += rarity * resultLevel;
+                        extraCost += rarity * Math.max(0, resultLevel - targetLevel);
                         if (target.getCount() > 1) {
                             extraCost = 40;
                         }


### PR DESCRIPTION
If the enchantment is compatible with the existing enchantments on the target:

* For Java Edition, add the final level of the enchantment on  the resulting item multiplied by the multiplier from the table below.
* For Bedrock Edition, add the difference between the final level  and the initial level on the target item multiplied by  the multiplier from the table below.

https://minecraft.gamepedia.com/Anvil/Mechanics#Costs_for_combining_enchantments

Fix #226 