### PR TITLE
Improves anvil security and reduces the risk of item loss

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -19,6 +19,14 @@ Click the link above to see the future.
 - [#226] Anvil cost calculation not applying bedrock edition reductions
 - [#222] Anvil changes the level twice and fails the transaction if the player doesn't have enough.
 - [#235] Wrong flags in MoveEntityAbsolutePacket
+- [#234] Failed anvil transactions caused all involved items to be destroyed
+- [#234] Visual desync in the player's experience level when an anvil transaction fails or is cancelled. 
+
+### Changed
+- [#234] Anvil's result is no longer stored in the PlayerUIInventory at slot 50 as 
+         it was vulnerable to heavy duplication exploits.
+- [#234] `setResult` methods in `AnvilInventory` are now deprecated and marked for removal at 1.3.0.0-PN
+         because it's not supported by the client and changing it will fail the transaction.
 
 ## [1.2.0.0-PN] - 2020-05-03 ([Check the milestone](https://github.com/GameModsBR/PowerNukkit/milestone/6?closed=1))
 **Note:** Effort has been made to keep this list accurate but some bufixes and new features might be missing here, specially those made by the NukkitX team and contributors.
@@ -195,4 +203,5 @@ Click the link above to see the future.
 [#224]: https://github.com/GameModsBR/PowerNukkit/pull/224
 [#226]: https://github.com/GameModsBR/PowerNukkit/issues/226
 [#228]: https://github.com/GameModsBR/PowerNukkit/issues/228
+[#234]: https://github.com/GameModsBR/PowerNukkit/issues/234
 [#235]: https://github.com/GameModsBR/PowerNukkit/issues/235

--- a/src/main/java/cn/nukkit/inventory/AnvilInventory.java
+++ b/src/main/java/cn/nukkit/inventory/AnvilInventory.java
@@ -314,7 +314,7 @@ public class AnvilInventory extends FakeBlockUIComponent {
     }
 
     /**
-     * @deprecated send parameter is deprecated
+     * @deprecated send parameter is deprecated. This method will be removed in 1.3.0.0-PN.
      */
     @Deprecated
     public boolean setResult(Item item, boolean send) {
@@ -322,7 +322,7 @@ public class AnvilInventory extends FakeBlockUIComponent {
     }
 
     /**
-     * @deprecated the client won't see this change, and the transaction might fail.
+     * @deprecated the client won't see this change, and the transaction might fail. This method will be removed from public in 1.3.0.0-PN.
      */
     @Deprecated
     public boolean setResult(Item item) {

--- a/src/main/java/cn/nukkit/inventory/AnvilInventory.java
+++ b/src/main/java/cn/nukkit/inventory/AnvilInventory.java
@@ -7,6 +7,7 @@ import cn.nukkit.item.enchantment.Enchantment;
 import cn.nukkit.level.Position;
 import cn.nukkit.nbt.tag.CompoundTag;
 import io.netty.util.internal.StringUtil;
+import lombok.NonNull;
 
 import java.util.Arrays;
 import java.util.Iterator;
@@ -24,10 +25,12 @@ public class AnvilInventory extends FakeBlockUIComponent {
     public static final int TARGET = 0;
     public static final int SACRIFICE = 1;
     public static final int RESULT = 50;
-    private static final int SLOT_RESULT = RESULT - OFFSET;
     
     private int levelCost;
     private String newItemName;
+    
+    @NonNull
+    private Item currentResult = Item.get(0);
 
     public AnvilInventory(PlayerUIInventory playerUI, Position position) {
         super(playerUI, InventoryType.ANVIL, OFFSET, position);
@@ -254,7 +257,7 @@ public class AnvilInventory extends FakeBlockUIComponent {
             return Item.get(0);
         }
         if (index == 2) {
-            index = SLOT_RESULT;
+            return getResult();
         }
         
         return super.getItem(index);
@@ -267,7 +270,7 @@ public class AnvilInventory extends FakeBlockUIComponent {
         }
         
         if (index == 2) {
-            index = SLOT_RESULT;
+            return setResult(item);
         }
         
         return super.setItem(index, item, send);
@@ -282,9 +285,18 @@ public class AnvilInventory extends FakeBlockUIComponent {
     }
     
     public Item getResult() {
-        return getItem(2);
+        return currentResult.clone();
     }
-    
+
+    @Override
+    public void sendContents(Player... players) {
+        super.sendContents(players);
+        // Fixes desync when transactions are cancelled.
+        for (Player player : players) {
+            player.sendExperienceLevel();
+        }
+    }
+
     public boolean setFirstItem(Item item, boolean send) {
         return setItem(SACRIFICE, item, send);
     }
@@ -300,13 +312,26 @@ public class AnvilInventory extends FakeBlockUIComponent {
     public boolean setSecondItem(Item item) {
         return setSecondItem(item, true);
     }
-    
+
+    /**
+     * @deprecated send parameter is deprecated
+     */
+    @Deprecated
     public boolean setResult(Item item, boolean send) {
         return setItem(2, item, send);
     }
-    
+
+    /**
+     * @deprecated the client won't see this change, and the transaction might fail.
+     */
+    @Deprecated
     public boolean setResult(Item item) {
-        return setResult(item, true);
+        if (item == null || item.isNull()) {
+            this.currentResult = Item.get(0);
+        } else {
+            this.currentResult = item.clone();
+        }
+        return true;
     }
     
     private static int getRepairCost(Item item) {

--- a/src/main/java/cn/nukkit/inventory/transaction/CraftingTransaction.java
+++ b/src/main/java/cn/nukkit/inventory/transaction/CraftingTransaction.java
@@ -14,6 +14,7 @@ import cn.nukkit.scheduler.Task;
 
 import java.util.Arrays;
 import java.util.List;
+import java.util.Optional;
 import java.util.concurrent.ThreadLocalRandom;
 
 /**
@@ -172,10 +173,10 @@ public class CraftingTransaction extends InventoryTransaction {
                                     actions.remove(a);
                                     actions.add(a);
                                 });
-                        anvil.setResult(Item.get(0), false);
                     }
                 }
             }
+            source.getUIInventory().setItem(AnvilInventory.RESULT, Item.get(0), false);
         } else if (craftingType == Player.CRAFTING_GRINDSTONE) {
             Inventory inventory = source.getWindowById(Player.GRINDSTONE_WINDOW_ID);
             if (inventory instanceof GrindstoneInventory) {
@@ -202,7 +203,13 @@ public class CraftingTransaction extends InventoryTransaction {
 
     protected void sendInventories() {
         super.sendInventories();
-
+        
+        Optional<Inventory> topWindow = source.getTopWindow();
+        if (topWindow.isPresent()) {
+            //source.removeWindow(topWindow.get());
+            return;
+        }
+        
 		/*
          * TODO: HACK!
 		 * we can't resend the contents of the crafting window, so we force the client to close it instead.
@@ -211,13 +218,14 @@ public class CraftingTransaction extends InventoryTransaction {
 		 */
         ContainerClosePacket pk = new ContainerClosePacket();
         pk.windowId = ContainerIds.NONE;
+        //TODO This hack causes PowerNukkit#223
         source.getServer().getScheduler().scheduleDelayedTask(new Task() {
             @Override
             public void onRun(int currentTick) {
                 source.dataPacket(pk);
             }
         }, 20);
-
+        
         this.source.resetCraftingGridType();
     }
 


### PR DESCRIPTION
This fixes a possible anvil exploit and fixes the items being destroyed when an anvil crafting transaction fails.

`setResult` is now deprecated because we can't force the client to accept a custom result this way, the client just ignores it. Manually changing it would make the transaction fail.

#225 