### PR TITLE
Adds equalsIgnoringEnchantmentOrder to Item and pull current 1.2.0.2-PN fixes

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,9 @@ Nukkit 1.X and 2.X.
 ## [Unreleased]
 Click the link above to see the future.
 
+### Fixes
+- [#239] Anvil fails to merge some enchantments because the ordering mismatches
+
 ## [1.2.0.1-PN] - 2020-05-08 ([Check the milestone](https://github.com/GameModsBR/PowerNukkit/milestone/8?closed=1))
 Fixes several anvil issues.
 
@@ -209,3 +212,4 @@ Fixes several anvil issues.
 [#228]: https://github.com/GameModsBR/PowerNukkit/issues/228
 [#234]: https://github.com/GameModsBR/PowerNukkit/issues/234
 [#235]: https://github.com/GameModsBR/PowerNukkit/issues/235
+[#239]: https://github.com/GameModsBR/PowerNukkit/issues/239

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,7 @@ Click the link above to see the future.
 
 ### Added
 - [#227] PlayerJumpEvent called when jump packets are received.
+- [#242] `Item.equalsIgnoringEnchantmentOrder` method for public usage.
 
 ### Changed
 - [#227] Sugar canes now fires BlockGrowEvent when growing naturally.
@@ -224,3 +225,4 @@ Fixes several anvil issues.
 [#234]: https://github.com/GameModsBR/PowerNukkit/issues/234
 [#235]: https://github.com/GameModsBR/PowerNukkit/issues/235
 [#239]: https://github.com/GameModsBR/PowerNukkit/issues/239
+[#242]: https://github.com/GameModsBR/PowerNukkit/pull/242

--- a/pom.xml
+++ b/pom.xml
@@ -11,7 +11,7 @@
     Upstream is the NukkitX major version
     PN is a indicator that software is running PowerNukkit, it must be present both in releases and snapshot versions
     -->
-    <version>1.2.0.1-PN</version>
+    <version>1.2.0.2-PN-SNAPSHOT</version>
 
     <properties>
         <maven.compiler.source>1.8</maven.compiler.source>

--- a/src/main/java/cn/nukkit/inventory/transaction/CraftingTransaction.java
+++ b/src/main/java/cn/nukkit/inventory/transaction/CraftingTransaction.java
@@ -8,13 +8,9 @@ import cn.nukkit.inventory.transaction.action.InventoryAction;
 import cn.nukkit.inventory.transaction.action.SlotChangeAction;
 import cn.nukkit.inventory.transaction.action.TakeLevelAction;
 import cn.nukkit.item.Item;
-import cn.nukkit.nbt.tag.CompoundTag;
-import cn.nukkit.nbt.tag.ListTag;
 import cn.nukkit.network.protocol.ContainerClosePacket;
 import cn.nukkit.network.protocol.types.ContainerIds;
 import cn.nukkit.scheduler.Task;
-import it.unimi.dsi.fastutil.ints.Int2IntArrayMap;
-import it.unimi.dsi.fastutil.ints.Int2IntMap;
 
 import java.util.Arrays;
 import java.util.List;
@@ -159,7 +155,7 @@ public class CraftingTransaction extends InventoryTransaction {
             if (inventory instanceof AnvilInventory) {
                 AnvilInventory anvil = (AnvilInventory) inventory;
                 addInventory(anvil);
-                if (equalsIgnoringEnchantmentOrder(this.primaryOutput, anvil.getResult(), true)) {
+                if (this.primaryOutput.equalsIgnoringEnchantmentOrder(anvil.getResult(), true)) {
                     TakeLevelAction takeLevel = new TakeLevelAction(anvil.getLevelCost());
                     addAction(takeLevel);
                     if (takeLevel.isValid(source)) {
@@ -196,56 +192,6 @@ public class CraftingTransaction extends InventoryTransaction {
         }
 
         return this.recipe != null && super.canExecute();
-    }
-
-    //TODO Move this to Item at 1.2.1.0-PN
-    @Deprecated
-    private boolean equalsIgnoringEnchantmentOrder(Item thisItem, Item item, boolean checkDamage) {
-        if (!thisItem.equals(item, checkDamage, false)) {
-            return false;
-        }
-
-        if (Arrays.equals(thisItem.getCompoundTag(), item.getCompoundTag())) {
-            return true;
-        }
-
-        if (!thisItem.hasCompoundTag() || !item.hasCompoundTag()) {
-            return false;
-        }
-
-        CompoundTag thisTags = thisItem.getNamedTag();
-        CompoundTag otherTags = item.getNamedTag();
-        if (thisTags.equals(otherTags)) {
-            return true;
-        }
-
-        if (!thisTags.contains("ench") || !otherTags.contains("ench")
-                || !(thisTags.get("ench") instanceof ListTag)
-                || !(otherTags.get("ench") instanceof ListTag)
-                || thisTags.getList("ench").size() != otherTags.getList("ench").size()) {
-            return false;
-        }
-
-        ListTag<CompoundTag> thisEnchantmentTags = thisTags.getList("ench", CompoundTag.class);
-        ListTag<CompoundTag> otherEnchantmentTags = otherTags.getList("ench", CompoundTag.class);
-
-        int size = thisEnchantmentTags.size();
-        Int2IntMap enchantments = new Int2IntArrayMap(size);
-        enchantments.defaultReturnValue(Integer.MIN_VALUE);
-
-        for (int i = 0; i < size; i++) {
-            CompoundTag tag = thisEnchantmentTags.get(i);
-            enchantments.put(tag.getShort("id"), tag.getShort("lvl"));
-        }
-
-        for (int i = 0; i < size; i++) {
-            CompoundTag tag = otherEnchantmentTags.get(i);
-            if (enchantments.get(tag.getShort("id")) != tag.getShort("lvl")) {
-                return false;
-            }
-        }
-
-        return true;
     }
 
     protected boolean callExecuteEvent() {

--- a/src/main/java/cn/nukkit/item/Item.java
+++ b/src/main/java/cn/nukkit/item/Item.java
@@ -19,6 +19,8 @@ import cn.nukkit.utils.Binary;
 import cn.nukkit.utils.Config;
 import cn.nukkit.utils.MainLogger;
 import cn.nukkit.utils.Utils;
+import it.unimi.dsi.fastutil.ints.Int2IntArrayMap;
+import it.unimi.dsi.fastutil.ints.Int2IntMap;
 
 import java.io.IOException;
 import java.nio.ByteOrder;
@@ -1062,6 +1064,58 @@ public class Item implements Cloneable, BlockID, ItemID {
      */
     public final boolean equalsExact(Item other) {
         return this.equals(other, true, true) && this.count == other.count;
+    }
+
+    /**
+     * Same as {@link #equals(Item, boolean)} but the enchantment order of the items does not affect the result.
+     * @since 1.2.1.0-PN
+     */
+    public final boolean equalsIgnoringEnchantmentOrder(Item item, boolean checkDamage) {
+        if (!this.equals(item, checkDamage, false)) {
+            return false;
+        }
+
+        if (Arrays.equals(this.getCompoundTag(), item.getCompoundTag())) {
+            return true;
+        }
+
+        if (!this.hasCompoundTag() || !item.hasCompoundTag()) {
+            return false;
+        }
+
+        CompoundTag thisTags = this.getNamedTag();
+        CompoundTag otherTags = item.getNamedTag();
+        if (thisTags.equals(otherTags)) {
+            return true;
+        }
+
+        if (!thisTags.contains("ench") || !otherTags.contains("ench")
+                || !(thisTags.get("ench") instanceof ListTag)
+                || !(otherTags.get("ench") instanceof ListTag)
+                || thisTags.getList("ench").size() != otherTags.getList("ench").size()) {
+            return false;
+        }
+
+        ListTag<CompoundTag> thisEnchantmentTags = thisTags.getList("ench", CompoundTag.class);
+        ListTag<CompoundTag> otherEnchantmentTags = otherTags.getList("ench", CompoundTag.class);
+
+        int size = thisEnchantmentTags.size();
+        Int2IntMap enchantments = new Int2IntArrayMap(size);
+        enchantments.defaultReturnValue(Integer.MIN_VALUE);
+
+        for (int i = 0; i < size; i++) {
+            CompoundTag tag = thisEnchantmentTags.get(i);
+            enchantments.put(tag.getShort("id"), tag.getShort("lvl"));
+        }
+
+        for (int i = 0; i < size; i++) {
+            CompoundTag tag = otherEnchantmentTags.get(i);
+            if (enchantments.get(tag.getShort("id")) != tag.getShort("lvl")) {
+                return false;
+            }
+        }
+
+        return true;
     }
 
     @Deprecated


### PR DESCRIPTION
This essentially pulls the fix for #239 (PR #241) and moves the new method to `Item` so it can be used by the public