### PR TITLE
Fixes anvil enchantment compatibility conditions

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,9 +9,14 @@ Nukkit 1.X and 2.X.
 ## [Unreleased 1.2.1.0-PN+]
 Click the link above to see the future.
 
+### Fixes
+- [#224] Enchantment compatibility rules when merging enchanted items in an anvil
+
 ### Added
 - [#227] PlayerJumpEvent called when jump packets are received.
 - [#242] `Item.equalsIgnoringEnchantmentOrder` method for public usage.
+- [#244] `Enchantment.getPowerNukkit().isItemAcceptable(Item)` to check if an enchantment can exist 
+         in a given item stack by any non-hack means.
 
 ### Changed
 - [#227] Sugar canes now fires BlockGrowEvent when growing naturally.
@@ -230,3 +235,4 @@ Fixes several anvil issues.
 [#240]: https://github.com/GameModsBR/PowerNukkit/issues/240
 [#242]: https://github.com/GameModsBR/PowerNukkit/pull/242
 [#243]: https://github.com/GameModsBR/PowerNukkit/issues/243
+[#244]: https://github.com/GameModsBR/PowerNukkit/pull/244

--- a/src/main/java/cn/nukkit/inventory/AnvilInventory.java
+++ b/src/main/java/cn/nukkit/inventory/AnvilInventory.java
@@ -120,7 +120,7 @@ public class AnvilInventory extends FakeBlockUIComponent {
                     Enchantment sacrificeEnchantment;
                     do {
                         if (!sacrificeEnchIter.hasNext()) {
-                            if (incompatibleFlag && !compatibleFlag) { // TODO These flags would never be positive?
+                            if (incompatibleFlag && !compatibleFlag) {
                                 setResult(Item.get(0));
                                 setLevelCost(0);
                                 return;
@@ -135,7 +135,7 @@ public class AnvilInventory extends FakeBlockUIComponent {
                     int targetLevel = resultEnchantment != null? resultEnchantment.getLevel() : 0;
                     int resultLevel = sacrificeEnchantment.getLevel();
                     resultLevel = targetLevel == resultLevel ? resultLevel + 1 : Math.max(resultLevel, targetLevel);
-                    boolean compatible = sacrificeEnchantment.canEnchant(target);
+                    boolean compatible = sacrificeEnchantment.getPowerNukkit().isItemAcceptable(target);
                     if (playerUI.getHolder().isCreative() || target.getId() == Item.ENCHANTED_BOOK) {
                         compatible = true;
                     }
@@ -144,7 +144,7 @@ public class AnvilInventory extends FakeBlockUIComponent {
             
                     while(targetEnchIter.hasNext()) {
                         Enchantment targetEnchantment = targetEnchIter.next();
-                        if (targetEnchantment.type != sacrificeEnchantment.type && (!sacrificeEnchantment.isCompatibleWith(targetEnchantment) || !targetEnchantment.isCompatibleWith(sacrificeEnchantment))) {
+                        if (targetEnchantment.id != sacrificeEnchantment.id && (!sacrificeEnchantment.isCompatibleWith(targetEnchantment) || !targetEnchantment.isCompatibleWith(sacrificeEnchantment))) {
                             compatible = false;
                             ++extraCost;
                         }

--- a/src/main/java/cn/nukkit/item/enchantment/Enchantment.java
+++ b/src/main/java/cn/nukkit/item/enchantment/Enchantment.java
@@ -140,6 +140,8 @@ public abstract class Enchantment implements Cloneable {
     protected int level = 1;
 
     protected final String name;
+    
+    private PowerNukkit powerNukkit;
 
     protected Enchantment(int id, String name, int weight, EnchantmentType type) {
         this.id = id;
@@ -240,6 +242,28 @@ public abstract class Enchantment implements Cloneable {
             return (Enchantment) super.clone();
         } catch (CloneNotSupportedException e) {
             return null;
+        }
+    }
+
+    /**
+     * @since 1.2.1.0-PN
+     */
+    public PowerNukkit getPowerNukkit() {
+        PowerNukkit powerNukkit = this.powerNukkit;
+        if (powerNukkit == null) this.powerNukkit = powerNukkit = new PowerNukkit();
+        return powerNukkit;
+    }
+
+    /**
+     * @since 1.2.1.0-PN
+     */
+    public class PowerNukkit {
+        /**
+         * Checks if an item can have this enchantment. It's not strict to the enchantment table.
+         * @since 1.2.1.0-PN
+         */
+        public boolean isItemAcceptable(Item item) {
+            return canEnchant(item);
         }
     }
 

--- a/src/main/java/cn/nukkit/item/enchantment/EnchantmentDurability.java
+++ b/src/main/java/cn/nukkit/item/enchantment/EnchantmentDurability.java
@@ -31,11 +31,6 @@ public class EnchantmentDurability extends Enchantment {
     }
 
     @Override
-    public boolean isCompatibleWith(Enchantment enchantment) {
-        return super.isCompatibleWith(enchantment) && enchantment.id != ID_FORTUNE_DIGGING;
-    }
-
-    @Override
     public boolean canEnchant(Item item) {
         return item.getMaxDurability() >= 0 || super.canEnchant(item);
     }

--- a/src/main/java/cn/nukkit/item/enchantment/EnchantmentDurability.java
+++ b/src/main/java/cn/nukkit/item/enchantment/EnchantmentDurability.java
@@ -9,6 +9,8 @@ import java.util.Random;
  * Nukkit Project
  */
 public class EnchantmentDurability extends Enchantment {
+    private PowerNukkit powerNukkit;
+    
     protected EnchantmentDurability() {
         super(ID_DURABILITY, "durability", 5, EnchantmentType.BREAKABLE);
     }
@@ -40,5 +42,31 @@ public class EnchantmentDurability extends Enchantment {
 
     public static boolean negateDamage(Item item, int level, Random random) {
         return !(item.isArmor() && random.nextFloat() < 0.6f) && random.nextInt(level + 1) > 0;
+    }
+    
+    /**
+     * @since 1.2.1.0-PN
+     */
+    @Override
+    public PowerNukkit getPowerNukkit() {
+        PowerNukkit powerNukkit = this.powerNukkit;
+        if (powerNukkit == null) this.powerNukkit = powerNukkit = new PowerNukkit();
+        return powerNukkit;
+    }
+
+    /**
+     * @since 1.2.1.0-PN
+     */
+    public class PowerNukkit extends Enchantment.PowerNukkit {
+        /**
+         * @since 1.2.1.0-PN
+         */
+        @Override
+        public boolean isItemAcceptable(Item item) {
+            if (!item.isNull() && item.getMaxDurability() != -1 && !item.isUnbreakable()) {
+                return true;
+            }
+            return super.isItemAcceptable(item);
+        }
     }
 }

--- a/src/main/java/cn/nukkit/item/enchantment/EnchantmentDurability.java
+++ b/src/main/java/cn/nukkit/item/enchantment/EnchantmentDurability.java
@@ -53,9 +53,6 @@ public class EnchantmentDurability extends Enchantment {
      * @since 1.2.1.0-PN
      */
     public class PowerNukkit extends Enchantment.PowerNukkit {
-        /**
-         * @since 1.2.1.0-PN
-         */
         @Override
         public boolean isItemAcceptable(Item item) {
             if (!item.isNull() && item.getMaxDurability() != -1 && !item.isUnbreakable()) {

--- a/src/main/java/cn/nukkit/item/enchantment/EnchantmentEfficiency.java
+++ b/src/main/java/cn/nukkit/item/enchantment/EnchantmentEfficiency.java
@@ -7,6 +7,8 @@ import cn.nukkit.item.Item;
  * Nukkit Project
  */
 public class EnchantmentEfficiency extends Enchantment {
+    private PowerNukkit powerNukkit;
+    
     protected EnchantmentEfficiency() {
         super(ID_EFFICIENCY, "digging", 10, EnchantmentType.DIGGER);
     }
@@ -29,6 +31,32 @@ public class EnchantmentEfficiency extends Enchantment {
     @Override
     public boolean canEnchant(Item item) {
         return item.isShears() || super.canEnchant(item);
+    }
+    
+    /**
+     * @since 1.2.1.0-PN
+     */
+    @Override
+    public PowerNukkit getPowerNukkit() {
+        PowerNukkit powerNukkit = this.powerNukkit;
+        if (powerNukkit == null) this.powerNukkit = powerNukkit = new PowerNukkit();
+        return powerNukkit;
+    }
+
+    /**
+     * @since 1.2.1.0-PN
+     */
+    public class PowerNukkit extends Enchantment.PowerNukkit {
+        /**
+         * @since 1.2.1.0-PN
+         */
+        @Override
+        public boolean isItemAcceptable(Item item) {
+            if (item.isShears()) {
+                return true;
+            }
+            return super.isItemAcceptable(item);
+        }
     }
 
 }

--- a/src/main/java/cn/nukkit/item/enchantment/EnchantmentEfficiency.java
+++ b/src/main/java/cn/nukkit/item/enchantment/EnchantmentEfficiency.java
@@ -47,9 +47,6 @@ public class EnchantmentEfficiency extends Enchantment {
      * @since 1.2.1.0-PN
      */
     public class PowerNukkit extends Enchantment.PowerNukkit {
-        /**
-         * @since 1.2.1.0-PN
-         */
         @Override
         public boolean isItemAcceptable(Item item) {
             if (item.isShears()) {

--- a/src/main/java/cn/nukkit/item/enchantment/EnchantmentSilkTouch.java
+++ b/src/main/java/cn/nukkit/item/enchantment/EnchantmentSilkTouch.java
@@ -7,6 +7,8 @@ import cn.nukkit.item.Item;
  * Nukkit Project
  */
 public class EnchantmentSilkTouch extends Enchantment {
+    private PowerNukkit powerNukkit;
+    
     protected EnchantmentSilkTouch() {
         super(ID_SILK_TOUCH, "untouching", 1, EnchantmentType.DIGGER);
     }
@@ -34,5 +36,32 @@ public class EnchantmentSilkTouch extends Enchantment {
     @Override
     public boolean canEnchant(Item item) {
         return item.isShears() || super.canEnchant(item);
+    }
+    
+    
+    /**
+     * @since 1.2.1.0-PN
+     */
+    @Override
+    public PowerNukkit getPowerNukkit() {
+        PowerNukkit powerNukkit = this.powerNukkit;
+        if (powerNukkit == null) this.powerNukkit = powerNukkit = new PowerNukkit();
+        return powerNukkit;
+    }
+
+    /**
+     * @since 1.2.1.0-PN
+     */
+    public class PowerNukkit extends Enchantment.PowerNukkit {
+        /**
+         * @since 1.2.1.0-PN
+         */
+        @Override
+        public boolean isItemAcceptable(Item item) {
+            if (item.isShears()) {
+                return true;
+            }
+            return super.isItemAcceptable(item);
+        }
     }
 }

--- a/src/main/java/cn/nukkit/item/enchantment/EnchantmentSilkTouch.java
+++ b/src/main/java/cn/nukkit/item/enchantment/EnchantmentSilkTouch.java
@@ -53,9 +53,6 @@ public class EnchantmentSilkTouch extends Enchantment {
      * @since 1.2.1.0-PN
      */
     public class PowerNukkit extends Enchantment.PowerNukkit {
-        /**
-         * @since 1.2.1.0-PN
-         */
         @Override
         public boolean isItemAcceptable(Item item) {
             if (item.isShears()) {

--- a/src/main/java/cn/nukkit/item/enchantment/EnchantmentThorns.java
+++ b/src/main/java/cn/nukkit/item/enchantment/EnchantmentThorns.java
@@ -5,6 +5,8 @@ import cn.nukkit.entity.EntityHumanType;
 import cn.nukkit.event.entity.EntityDamageByEntityEvent;
 import cn.nukkit.event.entity.EntityDamageEvent;
 import cn.nukkit.item.Item;
+import cn.nukkit.item.ItemArmor;
+import cn.nukkit.item.ItemElytra;
 
 import java.util.concurrent.ThreadLocalRandom;
 
@@ -13,6 +15,8 @@ import java.util.concurrent.ThreadLocalRandom;
  * Nukkit Project
  */
 public class EnchantmentThorns extends Enchantment {
+    private PowerNukkit powerNukkit;
+    
     protected EnchantmentThorns() {
         super(ID_THORNS, "thorns", 1, EnchantmentType.ARMOR_TORSO);
     }
@@ -53,6 +57,32 @@ public class EnchantmentThorns extends Enchantment {
 
         if (shouldHit(random, thornsLevel)) {
             attacker.attack(new EntityDamageByEntityEvent(entity, attacker, EntityDamageEvent.DamageCause.ENTITY_ATTACK, getDamage(random, level), 0f));
+        }
+    }
+
+    /**
+     * @since 1.2.1.0-PN
+     */
+    @Override
+    public PowerNukkit getPowerNukkit() {
+        PowerNukkit powerNukkit = this.powerNukkit;
+        if (powerNukkit == null) this.powerNukkit = powerNukkit = new PowerNukkit();
+        return powerNukkit;
+    }
+
+    /**
+     * @since 1.2.1.0-PN
+     */
+    public class PowerNukkit extends Enchantment.PowerNukkit {
+        /**
+         * @since 1.2.1.0-PN
+         */
+        @Override
+        public boolean isItemAcceptable(Item item) {
+            if (item instanceof ItemArmor) {
+                return !(item instanceof ItemElytra);
+            }
+            return super.isItemAcceptable(item);
         }
     }
 

--- a/src/main/java/cn/nukkit/item/enchantment/EnchantmentThorns.java
+++ b/src/main/java/cn/nukkit/item/enchantment/EnchantmentThorns.java
@@ -74,9 +74,6 @@ public class EnchantmentThorns extends Enchantment {
      * @since 1.2.1.0-PN
      */
     public class PowerNukkit extends Enchantment.PowerNukkit {
-        /**
-         * @since 1.2.1.0-PN
-         */
         @Override
         public boolean isItemAcceptable(Item item) {
             if (item instanceof ItemArmor) {

--- a/src/main/java/cn/nukkit/item/enchantment/bow/EnchantmentBowInfinity.java
+++ b/src/main/java/cn/nukkit/item/enchantment/bow/EnchantmentBowInfinity.java
@@ -12,6 +12,11 @@ public class EnchantmentBowInfinity extends EnchantmentBow {
     }
 
     @Override
+    public boolean isCompatibleWith(Enchantment enchantment) {
+        return super.isCompatibleWith(enchantment) && enchantment.id != Enchantment.ID_MENDING;
+    }
+
+    @Override
     public int getMinEnchantAbility(int level) {
         return 20;
     }

--- a/src/main/java/cn/nukkit/item/enchantment/damage/EnchantmentDamage.java
+++ b/src/main/java/cn/nukkit/item/enchantment/damage/EnchantmentDamage.java
@@ -17,6 +17,8 @@ public abstract class EnchantmentDamage extends Enchantment {
     }
 
     protected final TYPE damageType;
+    
+    private PowerNukkit powerNukkit;
 
     protected EnchantmentDamage(int id, String name, int weight, TYPE type) {
         super(id, name, weight, EnchantmentType.SWORD);
@@ -46,5 +48,31 @@ public abstract class EnchantmentDamage extends Enchantment {
     @Override
     public boolean isMajor() {
         return true;
+    }
+    
+    /**
+     * @since 1.2.1.0-PN
+     */
+    @Override
+    public PowerNukkit getPowerNukkit() {
+        PowerNukkit powerNukkit = this.powerNukkit;
+        if (powerNukkit == null) this.powerNukkit = powerNukkit = new PowerNukkit();
+        return powerNukkit;
+    }
+
+    /**
+     * @since 1.2.1.0-PN
+     */
+    public class PowerNukkit extends Enchantment.PowerNukkit {
+        /**
+         * @since 1.2.1.0-PN
+         */
+        @Override
+        public boolean isItemAcceptable(Item item) {
+            if (item.isAxe()) {
+                return true;
+            }
+            return super.isItemAcceptable(item);
+        }
     }
 }

--- a/src/main/java/cn/nukkit/item/enchantment/damage/EnchantmentDamage.java
+++ b/src/main/java/cn/nukkit/item/enchantment/damage/EnchantmentDamage.java
@@ -64,9 +64,6 @@ public abstract class EnchantmentDamage extends Enchantment {
      * @since 1.2.1.0-PN
      */
     public class PowerNukkit extends Enchantment.PowerNukkit {
-        /**
-         * @since 1.2.1.0-PN
-         */
         @Override
         public boolean isItemAcceptable(Item item) {
             if (item.isAxe()) {

--- a/src/main/java/cn/nukkit/item/enchantment/trident/EnchantmentTridentRiptide.java
+++ b/src/main/java/cn/nukkit/item/enchantment/trident/EnchantmentTridentRiptide.java
@@ -21,4 +21,11 @@ public class EnchantmentTridentRiptide extends EnchantmentTrident {
     public int getMaxLevel() {
         return 3;
     }
+
+    @Override
+    public boolean isCompatibleWith(Enchantment enchantment) {
+        return super.isCompatibleWith(enchantment) 
+                && enchantment.id != Enchantment.ID_TRIDENT_LOYALTY
+                && enchantment.id != Enchantment.ID_TRIDENT_CHANNELING;
+    }
 }


### PR DESCRIPTION
Fixes #237 

### Added:
* `Enchantment.getPowerNukkit().isItemAcceptable(Item)` to check if an enchantment can exists in a given item stack by any non-hack means.

### Fixes:
* The secondary item rules of all enchantments listed [in the wiki](https://minecraft.gamepedia.com/Enchanting#Summary_of_enchantments)

### Pending:
* Review all `isCompatibleWith` implementations
