### PR TITLE
Ignores the meta in air blocks when rendering to the client

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,6 +15,7 @@ Click the link above to see the future.
 - [#243] Anvils were charging more levels to merge punch books
 - [#246] Anvil checking the enchantment table property instead of the enchantment id
 - [#246] Compatibility rules for unbreaking, fortune, mending, riptide, loyalty and channeling enchantments.
+- [#248] Air blocks with metadata were being rendered as "UPDATE!" block (backward compatibility fix)
 
 ### Changed
 - [#247] Invalid BlockId:Meta combinations now log an error when found. It logs only once.
@@ -224,3 +225,4 @@ Fixes several anvil issues.
 [#243]: https://github.com/GameModsBR/PowerNukkit/issues/243
 [#246]: https://github.com/GameModsBR/PowerNukkit/issues/246
 [#247]: https://github.com/GameModsBR/PowerNukkit/pull/247
+[#248]: https://github.com/GameModsBR/PowerNukkit/pull/248

--- a/src/main/java/cn/nukkit/level/GlobalBlockPalette.java
+++ b/src/main/java/cn/nukkit/level/GlobalBlockPalette.java
@@ -100,6 +100,9 @@ public class GlobalBlockPalette {
     }
 
     public static int getOrCreateRuntimeId(int id, int meta) {
+        // Special case for PN-96 PowerNukkit#210 where the world contains blocks like 0:13, 0:7, etc
+        if (id == 0) meta = 0;
+        
         int legacyId = id << 6 | meta;
         int runtimeId = legacyToRuntimeId.get(legacyId);
         if (runtimeId == -1) {


### PR DESCRIPTION
Fixes the world in the screenshot of #210

![](https://user-images.githubusercontent.com/44708000/79347583-2391b500-7f34-11ea-9fa3-d24bc036f8d2.png)

It had a lot of air blocks with metadata set:
```
18:09:50 [ERROR] Found an unknown BlockId:Meta combination: 0:5, replacing with an "UPDATE!" block.
18:09:50 [ERROR] Found an unknown BlockId:Meta combination: 0:2, replacing with an "UPDATE!" block.
18:09:50 [ERROR] Found an unknown BlockId:Meta combination: 0:8, replacing with an "UPDATE!" block.
18:09:50 [ERROR] Found an unknown BlockId:Meta combination: 0:1, replacing with an "UPDATE!" block.
18:09:50 [ERROR] Found an unknown BlockId:Meta combination: 0:13, replacing with an "UPDATE!" block.
18:09:50 [ERROR] Found an unknown BlockId:Meta combination: 0:4, replacing with an "UPDATE!" block.
18:09:50 [ERROR] Found an unknown BlockId:Meta combination: 0:6, replacing with an "UPDATE!" block.
18:09:50 [ERROR] Found an unknown BlockId:Meta combination: 0:3, replacing with an "UPDATE!" block.
18:09:50 [ERROR] Found an unknown BlockId:Meta combination: 0:7, replacing with an "UPDATE!" block.
18:09:50 [ERROR] Found an unknown BlockId:Meta combination: 0:12, replacing with an "UPDATE!" block.
18:09:51 [ERROR] Found an unknown BlockId:Meta combination: 0:10, replacing with an "UPDATE!" block.
18:09:51 [ERROR] Found an unknown BlockId:Meta combination: 0:9, replacing with an "UPDATE!" block.
18:09:51 [ERROR] Found an unknown BlockId:Meta combination: 0:14, replacing with an "UPDATE!" block.
18:09:51 [ERROR] Found an unknown BlockId:Meta combination: 0:15, replacing with an "UPDATE!" block.
18:09:51 [ERROR] Found an unknown BlockId:Meta combination: 0:11, replacing with an "UPDATE!" block.
```