### PR TITLE
Fixes the sugarcane update logic

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -26,7 +26,9 @@ Click the link above to see the future.
 - [#255] Fix /status information in /debugpaste not being collected
 - [#260] Fix a stack overflow when setting off end crystals near to each other
 - [#260] Fix drops of block entity inventory contents on explosion
-- [#260] Check SUPPORTED_PROTOCOLS instead of CURRENT_PROTOCOL in `LoginPacket.decode()` 
+- [#260] Check SUPPORTED_PROTOCOLS instead of CURRENT_PROTOCOL in `LoginPacket.decode()`
+- [#79] Sugarcane can grow without water
+- [#262] Removing the water don't break the sugarcane (using empty bucket or breaking water flow)
 
 ### Changed
 - [#247] Invalid BlockId:Meta combinations now log an error when found. It logs only once
@@ -215,6 +217,7 @@ Fixes several anvil issues.
 [#56]: https://github.com/GameModsBR/PowerNukkit/pull/56
 [#57]: https://github.com/GameModsBR/PowerNukkit/pull/57
 [#58]: https://github.com/GameModsBR/PowerNukkit/pull/58
+[#79]: https://github.com/GameModsBR/PowerNukkit/issues/79
 [#80]: https://github.com/GameModsBR/PowerNukkit/pull/80
 [#87]: https://github.com/GameModsBR/PowerNukkit/issues/87
 [#93]: https://github.com/GameModsBR/PowerNukkit/issues/93
@@ -247,3 +250,4 @@ Fixes several anvil issues.
 [#254]: https://github.com/GameModsBR/PowerNukkit/issues/254
 [#255]: https://github.com/GameModsBR/PowerNukkit/pull/255
 [#260]: https://github.com/GameModsBR/PowerNukkit/pull/260
+[#262]: https://github.com/GameModsBR/PowerNukkit/pull/262

--- a/src/main/java/cn/nukkit/block/BlockLiquid.java
+++ b/src/main/java/cn/nukkit/block/BlockLiquid.java
@@ -9,6 +9,7 @@ import cn.nukkit.level.Level;
 import cn.nukkit.level.Sound;
 import cn.nukkit.level.particle.SmokeParticle;
 import cn.nukkit.math.AxisAlignedBB;
+import cn.nukkit.math.BlockFace;
 import cn.nukkit.math.Vector3;
 import cn.nukkit.network.protocol.LevelSoundEventPacket;
 import it.unimi.dsi.fastutil.longs.Long2ByteMap;
@@ -213,6 +214,14 @@ public abstract class BlockLiquid extends BlockTransparentMeta {
                     this.level.setBlock(this, 0, this, false, false);
                 } else if (layer0.getWaterloggingLevel() <= 0 || layer0.getWaterloggingLevel() == 1 && getDamage() > 0) {
                     this.level.setBlock(this, 1, Block.get(Block.AIR), true, true);
+                    // Special check for sugar canes
+                    Block up = up();
+                    for (BlockFace diagonalFace : BlockFace.Plane.HORIZONTAL) {
+                        Block diagonal = up.getSide(diagonalFace);
+                        if (diagonal.getId() == BlockID.SUGARCANE_BLOCK) {
+                            diagonal.onUpdate(Level.BLOCK_UPDATE_SCHEDULED);
+                        }
+                    }
                 }
             }
             this.level.scheduleUpdate(this, this.tickRate());
@@ -263,6 +272,16 @@ public abstract class BlockLiquid extends BlockTransparentMeta {
                         this.level.setBlock(this, layer, event.getTo(), true, true);
                         if (!decayed) {
                             this.level.scheduleUpdate(this, this.tickRate());
+                        }
+                        // Special check for sugar canes
+                        if (this instanceof BlockWater && !(event.getTo() instanceof BlockWater)) {
+                            Block up = up();
+                            for (BlockFace diagonalFace : BlockFace.Plane.HORIZONTAL) {
+                                Block diagonal = up.getSide(diagonalFace);
+                                if (diagonal.getId() == BlockID.SUGARCANE_BLOCK) {
+                                    diagonal.onUpdate(Level.BLOCK_UPDATE_SCHEDULED);
+                                }
+                            }
                         }
                     }
                 }

--- a/src/main/java/cn/nukkit/block/BlockSugarcane.java
+++ b/src/main/java/cn/nukkit/block/BlockSugarcane.java
@@ -8,7 +8,6 @@ import cn.nukkit.item.ItemSugarcane;
 import cn.nukkit.level.Level;
 import cn.nukkit.level.particle.BoneMealParticle;
 import cn.nukkit.math.BlockFace;
-import cn.nukkit.math.Vector3;
 import cn.nukkit.utils.BlockColor;
 
 /**
@@ -92,30 +91,49 @@ public class BlockSugarcane extends BlockFlowable {
 
     @Override
     public int onUpdate(int type) {
+        Level level = getLevel();
         if (type == Level.BLOCK_UPDATE_NORMAL) {
-            Block down = this.down();
-            if (down.isTransparent() && down.getId() != SUGARCANE_BLOCK) {
-                this.getLevel().useBreakOn(this);
-                return Level.BLOCK_UPDATE_NORMAL;
+            level.scheduleUpdate(this, 0);
+            return type;
+        }
+        
+        if (type == Level.BLOCK_UPDATE_SCHEDULED) {
+            if (!isSupportValid()) {
+                level.useBreakOn(this);
             }
-        } else if (type == Level.BLOCK_UPDATE_RANDOM) {
-            if (this.down().getId() != SUGARCANE_BLOCK) {
-                if (this.getDamage() == 0x0F) {
-                    for (int y = 1; y < 3; ++y) {
-                        Block b = this.getLevel().getBlock(new Vector3(this.x, this.y + y, this.z));
-                        if (b.getId() == AIR) {
-                            this.getLevel().setBlock(b, Block.get(BlockID.SUGARCANE_BLOCK), false);
-                            break;
-                        }
-                    }
-                    this.setDamage(0);
-                    this.getLevel().setBlock(this, this, false);
-                } else {
-                    this.setDamage(this.getDamage() + 1);
-                    this.getLevel().setBlock(this, this, false);
-                }
-                return Level.BLOCK_UPDATE_RANDOM;
+            return type;
+        }
+        
+        if (type == Level.BLOCK_UPDATE_RANDOM) {
+            if (!isSupportValid()) {
+                level.scheduleUpdate(this, 0);
+                return type;
             }
+            if (getDamage() < 15) {
+                setDamage(this.getDamage() + 1);
+                level.setBlock(this, this, false);
+                return type;
+            }
+            Block up = up();
+            if (up.getId() != AIR) {
+                return type;
+            }
+            
+            int height = 0;
+            for (Block down = this; height < 3 && down.getId() == SUGARCANE_BLOCK; height++) {
+                down = down.down();
+            }
+            if (height >= 3) {
+                return type;
+            }
+            
+            if (!level.setBlock(up, Block.get(BlockID.SUGARCANE_BLOCK), false)) {
+                return type;
+            }
+            
+            setDamage(0);
+            level.setBlock(this, this, false);
+            return type;
         }
         return 0;
     }
@@ -125,21 +143,30 @@ public class BlockSugarcane extends BlockFlowable {
         if (block.getId() != AIR) {
             return false;
         }
-        Block down = this.down();
-        if (down.getId() == SUGARCANE_BLOCK) {
-            this.getLevel().setBlock(block, Block.get(BlockID.SUGARCANE_BLOCK), true);
+        if (isSupportValid()) {
+            this.getLevel().setBlock(block, this, true);
             return true;
-        } else if (down.getId() == GRASS || down.getId() == DIRT || down.getId() == SAND) {
-            Block block0 = down.north();
-            Block block1 = down.south();
-            Block block2 = down.west();
-            Block block3 = down.east();
-            if (block0 instanceof BlockWater || block1 instanceof BlockWater || block2 instanceof BlockWater || block3 instanceof BlockWater || block0 instanceof BlockIceFrosted || block1 instanceof BlockIceFrosted || block2 instanceof BlockIceFrosted || block3 instanceof BlockIceFrosted
-                || block0.getLevelBlockAtLayer(1) instanceof BlockWater || block1.getLevelBlockAtLayer(1) instanceof BlockWater
-                    || block2.getLevelBlockAtLayer(1) instanceof BlockWater || block3.getLevelBlockAtLayer(1) instanceof BlockWater
-                    || block0.getLevelBlockAtLayer(1) instanceof BlockIceFrosted || block1.getLevelBlockAtLayer(1) instanceof BlockIceFrosted
-                    || block2.getLevelBlockAtLayer(1) instanceof BlockIceFrosted || block3.getLevelBlockAtLayer(1) instanceof BlockIceFrosted) {
-                this.getLevel().setBlock(block, Block.get(BlockID.SUGARCANE_BLOCK), true);
+        }
+        return false;
+    }
+
+    /**
+     * @since 1.2.0.2-PN
+     */
+    private boolean isSupportValid() {
+        Block down = this.down();
+        int downId = down.getId();
+        if (downId == SUGARCANE_BLOCK) {
+            return true;
+        }
+        if (downId != GRASS && downId != DIRT && downId != SAND) {
+            return false;
+        }
+        for (BlockFace face : BlockFace.Plane.HORIZONTAL) {
+            Block possibleWater = down.getSide(face);
+            if (possibleWater instanceof BlockWater
+                    || possibleWater instanceof BlockIceFrosted
+                    || possibleWater.getLevelBlockAtLayer(1) instanceof BlockWater) {
                 return true;
             }
         }

--- a/src/main/java/cn/nukkit/block/BlockSugarcane.java
+++ b/src/main/java/cn/nukkit/block/BlockSugarcane.java
@@ -120,8 +120,8 @@ public class BlockSugarcane extends BlockFlowable {
             }
             
             int height = 0;
-            for (Block down = this; height < 3 && down.getId() == SUGARCANE_BLOCK; height++) {
-                down = down.down();
+            for (Block current = this; height < 3 && current.getId() == SUGARCANE_BLOCK; height++) {
+                current = current.down();
             }
             if (height >= 3) {
                 return type;

--- a/src/main/java/cn/nukkit/item/ItemBucket.java
+++ b/src/main/java/cn/nukkit/item/ItemBucket.java
@@ -119,6 +119,14 @@ public class ItemBucket extends Item {
                         level.addLevelSoundEvent(block, LevelSoundEventPacket.SOUND_BUCKET_FILL_LAVA);
                     } else {
                         level.addLevelSoundEvent(block, LevelSoundEventPacket.SOUND_BUCKET_FILL_WATER);
+                        // Special check for sugar canes
+                        Block up = target.up();
+                        for (BlockFace diagonalFace : Plane.HORIZONTAL) {
+                            Block diagonal = up.getSide(diagonalFace);
+                            if (diagonal.getId() == BlockID.SUGARCANE_BLOCK) {
+                                diagonal.onUpdate(Level.BLOCK_UPDATE_SCHEDULED);
+                            }
+                        }
                     }
 
                     return true;


### PR DESCRIPTION
* Fixes #79
* Makes the sugarcane breaks when the water is removed from bucket or decaying (other conditions will be handled in 1.2.1.0-PN)
* Makes huge sugarcanes breaks slowly instead of breaking all at once, just like vanilla