### PR TITLE
Fixes Disconnect messages not reaching the player sometimes

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -29,6 +29,7 @@ Click the link above to see the future.
 - [#260] Check SUPPORTED_PROTOCOLS instead of CURRENT_PROTOCOL in `LoginPacket.decode()`
 - [#79] Sugarcane can grow without water
 - [#262] Removing the water don't break the sugarcane (using empty bucket or breaking water flow)
+- [#263] Fixes disconnect messages not reaching the player sometimes
 
 ### Changed
 - [#247] Invalid BlockId:Meta combinations now log an error when found. It logs only once
@@ -251,3 +252,4 @@ Fixes several anvil issues.
 [#255]: https://github.com/GameModsBR/PowerNukkit/pull/255
 [#260]: https://github.com/GameModsBR/PowerNukkit/pull/260
 [#262]: https://github.com/GameModsBR/PowerNukkit/pull/262
+[#263]: https://github.com/GameModsBR/PowerNukkit/pull/263

--- a/src/main/java/cn/nukkit/Player.java
+++ b/src/main/java/cn/nukkit/Player.java
@@ -2152,11 +2152,11 @@ public class Player extends EntityHuman implements CommandSender, InventoryHolde
                         if (loginPacket.getProtocol() < ProtocolInfo.CURRENT_PROTOCOL) {
                             message = "disconnectionScreen.outdatedClient";
 
-                            this.sendPlayStatus(PlayStatusPacket.LOGIN_FAILED_CLIENT);
+                            this.sendPlayStatus(PlayStatusPacket.LOGIN_FAILED_CLIENT, true);
                         } else {
                             message = "disconnectionScreen.outdatedServer";
 
-                            this.sendPlayStatus(PlayStatusPacket.LOGIN_FAILED_SERVER);
+                            this.sendPlayStatus(PlayStatusPacket.LOGIN_FAILED_SERVER, true);
                         }
                         if (((LoginPacket) packet).protocol < 137) {
                             DisconnectPacket disconnectPacket = new DisconnectPacket();

--- a/src/main/java/cn/nukkit/Server.java
+++ b/src/main/java/cn/nukkit/Server.java
@@ -709,7 +709,7 @@ public class Server {
         } else {
             try {
                 byte[] data = Binary.appendBytes(payload);
-                this.broadcastPacketsCallback(Zlib.deflate(data, this.networkCompressionLevel), targets);
+                this.broadcastPacketsCallback(Zlib.deflate(data, this.networkCompressionLevel), targets, forceSync);
             } catch (Exception e) {
                 throw new RuntimeException(e);
             }
@@ -718,12 +718,29 @@ public class Server {
     }
 
     public void broadcastPacketsCallback(byte[] data, List<InetSocketAddress> targets) {
+        broadcastPacketsCallback(data, targets, false);
+    }
+
+    /**
+     * @since 1.2.0.2-PN
+     * @apiNote Only in PowerNukkit
+     */
+    private void broadcastPacketsCallback(byte[] data, List<InetSocketAddress> targets, boolean immediate) {
         BatchPacket pk = new BatchPacket();
         pk.payload = data;
 
-        for (InetSocketAddress i : targets) {
-            if (this.players.containsKey(i)) {
-                this.players.get(i).dataPacket(pk);
+        // The duplicated for is a micro-optimization
+        if (immediate) {
+            for (InetSocketAddress i : targets) {
+                if (this.players.containsKey(i)) {
+                    this.players.get(i).directDataPacket(pk);
+                }
+            }
+        } else {
+            for (InetSocketAddress i : targets) {
+                if (this.players.containsKey(i)) {
+                    this.players.get(i).dataPacket(pk);
+                }
             }
         }
     }


### PR DESCRIPTION
Fixes #238 

Messages now appears correctly:
* When the player's protocol version is not compatible with the server
* The player is kicked on login by a plugin cancelling the `PlayerLoginEvent`
* The `Player.close()` is called with any overload combination
* The server is closed
* A `DisconnectPacket` is sent to the player using the `Player.directDataPacket(DataPacket)` method