### PR TITLE
Pulls> Don't run checkInteractNearby on every tick

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -43,6 +43,7 @@ Click the link above to see the future.
 - [#268] The `/xp` command now makes level up sound every 5 levels
 - [#273] If an anvil, grindstone, enchanting, stonecutter, crafting GUI closes, the items will try to go to the player's inventory
 - [#273] `FakeBlockUIComponent.close(Player)` now calls `onClose(Player)`
+- [#274] `Player.checkInteractNearby()` is now called once every 10 ticks, it was called every tick
 
 ## [1.2.0.1-PN] - 2020-05-08 ([Check the milestone](https://github.com/GameModsBR/PowerNukkit/milestone/8?closed=1))
 Fixes several anvil issues.
@@ -268,3 +269,4 @@ Fixes several anvil issues.
 [#267]: https://github.com/GameModsBR/PowerNukkit/issues/267
 [#268]: https://github.com/GameModsBR/PowerNukkit/pull/268
 [#273]: https://github.com/GameModsBR/PowerNukkit/pull/273
+[#274]: https://github.com/GameModsBR/PowerNukkit/pull/274

--- a/src/main/java/cn/nukkit/Player.java
+++ b/src/main/java/cn/nukkit/Player.java
@@ -1786,7 +1786,10 @@ public class Player extends EntityHuman implements CommandSender, InventoryHolde
         }
 
         this.checkTeleportPosition();
-        this.checkInteractNearby();
+        
+        if (currentTick % 10 == 0) {
+            this.checkInteractNearby();
+        }
 
         if (this.spawned && this.dummyBossBars.size() > 0 && currentTick % 100 == 0) {
             this.dummyBossBars.values().forEach(DummyBossBar::updateBossEntityPosition);


### PR DESCRIPTION
Whatever this method is required for (something with vehicle interaction on mobile I guess) it surely doesn't have to run on every tick. Because of the usage of `getEntityPlayerLookingAt` not running this on every tick will improve the server performance especially when there are many players online. I didn't find any side effects from this change.

(cherry picked from commit 090684492c36dc8562c49c795d52997dbdcfd529)