### PR TITLE
Adds banner patterns and new annotations

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -21,6 +21,8 @@ Click the link above to see the future.
 - [#259] `Hash.hashBlock(Vector3)` method for public usage.
 - [#261] `Player.isCheckingMovement()` method for public usage.
 - [#261] Protected field `EntityEndCrystal.detonated` to disable the `EndCrystal.explode()` method.
+- [#275] New annotations to document when elements get added and when deprecated elements will be removed
+- [#123] Adds and register the banner pattern items 
 
 ### Changed
 - [#227] Sugar canes now fires BlockGrowEvent when growing naturally.
@@ -260,6 +262,7 @@ Fixes several anvil issues.
 [#103]: https://github.com/GameModsBR/PowerNukkit/issues/103
 [#108]: https://github.com/GameModsBR/PowerNukkit/pull/108
 [#116]: https://github.com/GameModsBR/PowerNukkit/issues/116
+[#123]: https://github.com/GameModsBR/PowerNukkit/issues/123
 [#129]: https://github.com/GameModsBR/PowerNukkit/pull/129
 [#140]: https://github.com/GameModsBR/PowerNukkit/pull/140
 [#152]: https://github.com/GameModsBR/PowerNukkit/pull/152
@@ -299,3 +302,4 @@ Fixes several anvil issues.
 [#268]: https://github.com/GameModsBR/PowerNukkit/pull/268
 [#273]: https://github.com/GameModsBR/PowerNukkit/pull/273
 [#274]: https://github.com/GameModsBR/PowerNukkit/pull/274
+[#275]: https://github.com/GameModsBR/PowerNukkit/pull/275

--- a/src/main/java/cn/nukkit/api/DeprecationDetails.java
+++ b/src/main/java/cn/nukkit/api/DeprecationDetails.java
@@ -1,0 +1,34 @@
+package cn.nukkit.api;
+
+import java.lang.annotation.ElementType;
+import java.lang.annotation.Retention;
+import java.lang.annotation.RetentionPolicy;
+import java.lang.annotation.Target;
+
+/**
+ * Describe the deprecation with more details. This is persisted to the class file, so it can be read without javadocs.
+ */
+@Retention(RetentionPolicy.CLASS)
+@Target({ElementType.CONSTRUCTOR, ElementType.METHOD, ElementType.ANNOTATION_TYPE, ElementType.TYPE,
+        ElementType.FIELD, ElementType.PACKAGE})
+public @interface DeprecationDetails {
+    /**
+     * The version which marked this element as deprecated.
+     */
+    String since();
+
+    /**
+     * Why it is deprecated.
+     */
+    String reason();
+
+    /**
+     * What should be used or do instead.
+     */
+    String replaceWith() default "";
+
+    /**
+     * When the annotated element will be removed or have it's signature changed.
+     */
+    String toBeRemovedAt() default "";
+}

--- a/src/main/java/cn/nukkit/api/PowerNukkitOnly.java
+++ b/src/main/java/cn/nukkit/api/PowerNukkitOnly.java
@@ -1,0 +1,17 @@
+package cn.nukkit.api;
+
+import java.lang.annotation.ElementType;
+import java.lang.annotation.Retention;
+import java.lang.annotation.RetentionPolicy;
+import java.lang.annotation.Target;
+
+/**
+ * Indicates that the annotated element is only available in PowerNukkit environment
+ * and will cause issues when used in a normal NukkitX server without PowerNukkit's patches and features. 
+ */
+@Retention(RetentionPolicy.CLASS)
+@Target({ElementType.CONSTRUCTOR, ElementType.METHOD, ElementType.ANNOTATION_TYPE, ElementType.TYPE,
+        ElementType.FIELD, ElementType.PACKAGE})
+@PowerNukkitOnly @Since("1.2.1.0-PN")
+public @interface PowerNukkitOnly {
+}

--- a/src/main/java/cn/nukkit/api/Since.java
+++ b/src/main/java/cn/nukkit/api/Since.java
@@ -1,0 +1,19 @@
+package cn.nukkit.api;
+
+import java.lang.annotation.ElementType;
+import java.lang.annotation.Retention;
+import java.lang.annotation.RetentionPolicy;
+import java.lang.annotation.Target;
+
+/**
+ * Indicates which version added the annotated element.
+ */
+@Retention(RetentionPolicy.CLASS)
+@Target({ElementType.CONSTRUCTOR, ElementType.METHOD, ElementType.ANNOTATION_TYPE, ElementType.TYPE,
+        ElementType.FIELD, ElementType.PACKAGE})
+public @interface Since {
+    /**
+     * The version which added the element.
+     */
+    String value();
+}

--- a/src/main/java/cn/nukkit/item/Item.java
+++ b/src/main/java/cn/nukkit/item/Item.java
@@ -264,6 +264,7 @@ public class Item implements Cloneable, BlockID, ItemID {
             list[DARK_OAK_DOOR] = ItemDoorDarkOak.class; //431
             list[CHORUS_FRUIT] = ItemChorusFruit.class; //432
             //TODO: list[POPPED_CHORUS_FRUIT] = ItemChorusFruitPopped.class; //433
+            list[BANNER_PATTERN] = ItemBannerPattern.class; //434
 
             //TODO: list[DRAGON_BREATH] = ItemDragonBreath.class; //437
             list[SPLASH_POTION] = ItemPotionSplash.class; //438

--- a/src/main/java/cn/nukkit/item/ItemBannerPattern.java
+++ b/src/main/java/cn/nukkit/item/ItemBannerPattern.java
@@ -1,0 +1,64 @@
+package cn.nukkit.item;
+
+import cn.nukkit.api.PowerNukkitOnly;
+import cn.nukkit.api.Since;
+
+@Since("1.2.1.0-PN")
+@PowerNukkitOnly
+public class ItemBannerPattern extends Item {
+    public static final int PATTERN_CREEPER_CHARGE = 0;
+    public static final int PATTERN_SKULL_CHARGE = 1;
+    public static final int PATTERN_FLOWER_CHARGE = 2;
+    public static final int PATTERN_THING = 3;
+    public static final int PATTERN_FIELD_MASONED = 4;
+    public static final int PATTERN_BORDURE_INDENTED = 5;
+
+    public ItemBannerPattern() {
+        this(0, 1);
+    }
+
+    public ItemBannerPattern(Integer meta) {
+        this(meta, 1);
+    }
+
+    public ItemBannerPattern(Integer meta, int count) {
+        super(BANNER_PATTERN, meta, count, "Bone");
+        updateName();
+    }
+
+    @Override
+    public int getMaxStackSize() {
+        return 1;
+    }
+
+    @Override
+    public void setDamage(Integer meta) {
+        super.setDamage(meta);
+        updateName();
+    }
+
+    protected void updateName() {
+        switch (super.meta % 6) {
+            case PATTERN_CREEPER_CHARGE:
+                name = "Creeper Charge Banner Pattern";
+                return;
+            case PATTERN_SKULL_CHARGE:
+                name = "Skull Charge Banner Pattern";
+                return;
+            case PATTERN_FLOWER_CHARGE:
+                name = "Flower Charge Banner Pattern";
+                return;
+            case PATTERN_THING:
+                name = "Thing Banner Pattern";
+                return;
+            case PATTERN_FIELD_MASONED:
+                name = "Field Banner Pattern";
+                return;
+            case PATTERN_BORDURE_INDENTED:
+                name = "Bordure Idented Banner Pattern";
+                return;
+            default:
+                name = "Banner Pattern";
+        }
+    }
+}

--- a/src/main/java/cn/nukkit/item/ItemID.java
+++ b/src/main/java/cn/nukkit/item/ItemID.java
@@ -1,5 +1,8 @@
 package cn.nukkit.item;
 
+import cn.nukkit.api.PowerNukkitOnly;
+import cn.nukkit.api.Since;
+
 public interface ItemID {
     int IRON_SHOVEL = 256;
     int IRON_PICKAXE = 257;
@@ -199,6 +202,10 @@ public interface ItemID {
     int DARK_OAK_DOOR = 431;
     int CHORUS_FRUIT = 432;
     int POPPED_CHORUS_FRUIT = 433;
+    
+    @Since("1.2.1.0-PN")
+    @PowerNukkitOnly 
+    int BANNER_PATTERN = 434;
 
     int DRAGON_BREATH = 437;
     int SPLASH_POTION = 438;


### PR DESCRIPTION
The annotations helps to flag when methods were added and when they will be removed when they are deprecated. Also helps to inform what to do with the deprecated elements. They don't depend on javadoc, so users who have only the binary files will be able to see them.

Also adds and registers the item banner. Resolves #123 