### PR TITLE
Fixes behives+bees+creative and add new methods to Block

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,7 @@ Click the link above to see the future.
 
 ### Fixes
 - [#224] Enchantment compatibility rules when merging enchanted items in an anvil
+- [#113] Behives not dropping in creative when it has bees
 
 ### Added
 - [#227] PlayerJumpEvent called when jump packets are received.
@@ -24,6 +25,7 @@ Click the link above to see the future.
 - [#275] New annotations to document when elements get added and when deprecated elements will be removed
 - [#123] Adds and register the banner pattern items
 - [#276] `Block.afterRemoval()` called automatically when the block is replaced using any `Level.setBlock()`
+- [#277] `Block.mustSilkTouch()` and `Block.mustDrop()` to allow blocks to force the dropping behaviour when being broken
 
 ### Changed
 - [#227] Sugar canes now fires BlockGrowEvent when growing naturally.
@@ -262,6 +264,7 @@ Fixes several anvil issues.
 [#102]: https://github.com/GameModsBR/PowerNukkit/pull/102
 [#103]: https://github.com/GameModsBR/PowerNukkit/issues/103
 [#108]: https://github.com/GameModsBR/PowerNukkit/pull/108
+[#113]: https://github.com/GameModsBR/PowerNukkit/issues/113
 [#116]: https://github.com/GameModsBR/PowerNukkit/issues/116
 [#123]: https://github.com/GameModsBR/PowerNukkit/issues/123
 [#129]: https://github.com/GameModsBR/PowerNukkit/pull/129
@@ -305,3 +308,4 @@ Fixes several anvil issues.
 [#274]: https://github.com/GameModsBR/PowerNukkit/pull/274
 [#275]: https://github.com/GameModsBR/PowerNukkit/pull/275
 [#276]: https://github.com/GameModsBR/PowerNukkit/pull/276
+[#277]: https://github.com/GameModsBR/PowerNukkit/pull/277

--- a/src/main/java/cn/nukkit/api/DeprecationDetails.java
+++ b/src/main/java/cn/nukkit/api/DeprecationDetails.java
@@ -1,6 +1,9 @@
 package cn.nukkit.api;
 
-import java.lang.annotation.*;
+import java.lang.annotation.ElementType;
+import java.lang.annotation.Retention;
+import java.lang.annotation.RetentionPolicy;
+import java.lang.annotation.Target;
 
 /**
  * Describe the deprecation with more details. This is persisted to the class file, so it can be read without javadocs.
@@ -8,7 +11,6 @@ import java.lang.annotation.*;
 @Retention(RetentionPolicy.CLASS)
 @Target({ElementType.CONSTRUCTOR, ElementType.METHOD, ElementType.ANNOTATION_TYPE, ElementType.TYPE,
         ElementType.FIELD, ElementType.PACKAGE})
-@Inherited
 public @interface DeprecationDetails {
     /**
      * The version which marked this element as deprecated.

--- a/src/main/java/cn/nukkit/api/DeprecationDetails.java
+++ b/src/main/java/cn/nukkit/api/DeprecationDetails.java
@@ -1,9 +1,6 @@
 package cn.nukkit.api;
 
-import java.lang.annotation.ElementType;
-import java.lang.annotation.Retention;
-import java.lang.annotation.RetentionPolicy;
-import java.lang.annotation.Target;
+import java.lang.annotation.*;
 
 /**
  * Describe the deprecation with more details. This is persisted to the class file, so it can be read without javadocs.
@@ -11,6 +8,7 @@ import java.lang.annotation.Target;
 @Retention(RetentionPolicy.CLASS)
 @Target({ElementType.CONSTRUCTOR, ElementType.METHOD, ElementType.ANNOTATION_TYPE, ElementType.TYPE,
         ElementType.FIELD, ElementType.PACKAGE})
+@Documented
 public @interface DeprecationDetails {
     /**
      * The version which marked this element as deprecated.

--- a/src/main/java/cn/nukkit/api/PowerNukkitOnly.java
+++ b/src/main/java/cn/nukkit/api/PowerNukkitOnly.java
@@ -11,5 +11,6 @@ import java.lang.annotation.*;
         ElementType.FIELD, ElementType.PACKAGE})
 @PowerNukkitOnly @Since("1.2.1.0-PN")
 @Inherited
+@Documented
 public @interface PowerNukkitOnly {
 }

--- a/src/main/java/cn/nukkit/api/Since.java
+++ b/src/main/java/cn/nukkit/api/Since.java
@@ -1,9 +1,6 @@
 package cn.nukkit.api;
 
-import java.lang.annotation.ElementType;
-import java.lang.annotation.Retention;
-import java.lang.annotation.RetentionPolicy;
-import java.lang.annotation.Target;
+import java.lang.annotation.*;
 
 /**
  * Indicates which version added the annotated element.
@@ -11,6 +8,7 @@ import java.lang.annotation.Target;
 @Retention(RetentionPolicy.CLASS)
 @Target({ElementType.CONSTRUCTOR, ElementType.METHOD, ElementType.ANNOTATION_TYPE, ElementType.TYPE,
         ElementType.FIELD, ElementType.PACKAGE})
+@Documented
 public @interface Since {
     /**
      * The version which added the element.

--- a/src/main/java/cn/nukkit/api/Since.java
+++ b/src/main/java/cn/nukkit/api/Since.java
@@ -1,6 +1,9 @@
 package cn.nukkit.api;
 
-import java.lang.annotation.*;
+import java.lang.annotation.ElementType;
+import java.lang.annotation.Retention;
+import java.lang.annotation.RetentionPolicy;
+import java.lang.annotation.Target;
 
 /**
  * Indicates which version added the annotated element.
@@ -8,7 +11,6 @@ import java.lang.annotation.*;
 @Retention(RetentionPolicy.CLASS)
 @Target({ElementType.CONSTRUCTOR, ElementType.METHOD, ElementType.ANNOTATION_TYPE, ElementType.TYPE,
         ElementType.FIELD, ElementType.PACKAGE})
-@Inherited
 public @interface Since {
     /**
      * The version which added the element.

--- a/src/main/java/cn/nukkit/block/Block.java
+++ b/src/main/java/cn/nukkit/block/Block.java
@@ -1216,6 +1216,18 @@ public abstract class Block extends Position implements Metadatable, Cloneable, 
         return false;
     }
     
+    @PowerNukkitOnly
+    @Since("1.2.1.0-PN")
+    public boolean mustSilkTouch(Vector3 vector, int layer, BlockFace face, Item item, Player player) {
+        return false;
+    }
+
+    @PowerNukkitOnly
+    @Since("1.2.1.0-PN")
+    public boolean mustDrop(Vector3 vector, int layer, BlockFace face, Item item, Player player) {
+        return false;
+    }
+    
     public Optional<Block> firstInLayers(Predicate<Block> condition) {
         return firstInLayers(0, condition);
     }

--- a/src/main/java/cn/nukkit/block/BlockBeehive.java
+++ b/src/main/java/cn/nukkit/block/BlockBeehive.java
@@ -10,6 +10,7 @@ import cn.nukkit.item.ItemTool;
 import cn.nukkit.level.Sound;
 import cn.nukkit.math.BlockFace;
 import cn.nukkit.math.NukkitMath;
+import cn.nukkit.math.Vector3;
 import cn.nukkit.nbt.tag.CompoundTag;
 import cn.nukkit.utils.BlockColor;
 import cn.nukkit.utils.Faceable;
@@ -157,7 +158,23 @@ public class BlockBeehive extends BlockSolidMeta implements Faceable {
     public boolean canSilkTouch() {
         return true;
     }
-    
+
+    @Override
+    public boolean mustSilkTouch(Vector3 vector, int layer, BlockFace face, Item item, Player player) {
+        if (player != null) {
+            BlockEntity blockEntity = getLevel().getBlockEntity(this);
+            if (blockEntity instanceof BlockEntityBeehive && !((BlockEntityBeehive) blockEntity).isEmpty()) {
+                return true;
+            }
+        }
+        return super.mustSilkTouch(vector, layer, face, item, player);
+    }
+
+    @Override
+    public boolean mustDrop(Vector3 vector, int layer, BlockFace face, Item item, Player player) {
+        return mustSilkTouch(vector, layer, face, item, player) || super.mustDrop(vector, layer, face, item, player);
+    }
+
     @Override
     public boolean canHarvestWithHand() {
         return true;

--- a/src/main/java/cn/nukkit/level/Level.java
+++ b/src/main/java/cn/nukkit/level/Level.java
@@ -1995,8 +1995,10 @@ public class Level implements ChunkManager, Metadatable {
         if (item == null) {
             item = new ItemBlock(Block.get(BlockID.AIR), 0, 0);
         }
-
-        boolean isSilkTouch = item.getEnchantment(Enchantment.ID_SILK_TOUCH) != null;
+        
+        boolean mustDrop = target.mustDrop(vector, layer, face, item, player);
+        boolean mustSilkTouch = target.mustSilkTouch(vector, layer, face, item, player);
+        boolean isSilkTouch = mustSilkTouch || item.getEnchantment(Enchantment.ID_SILK_TOUCH) != null;
 
         if (player != null) {
             if (player.getGamemode() == 2) {
@@ -2044,9 +2046,9 @@ public class Level implements ChunkManager, Metadatable {
             breakTime -= 0.15;
 
             Item[] eventDrops;
-            if (!setBlockDestroy && !player.isSurvival()) {
+            if (!mustDrop && !setBlockDestroy && !player.isSurvival()) {
                 eventDrops = new Item[0];
-            } else if (isSilkTouch && target.canSilkTouch()) {
+            } else if (mustSilkTouch || isSilkTouch && target.canSilkTouch()) {
                 eventDrops = new Item[]{target.toItem()};
             } else {
                 eventDrops = target.getDrops(item);
@@ -2082,7 +2084,7 @@ public class Level implements ChunkManager, Metadatable {
             }
         } else if (!target.isBreakable(item)) {
             return null;
-        } else if (item.getEnchantment(Enchantment.ID_SILK_TOUCH) != null) {
+        } else if (isSilkTouch) {
             drops = new Item[]{target.toItem()};
         } else {
             drops = target.getDrops(item);
@@ -2125,11 +2127,11 @@ public class Level implements ChunkManager, Metadatable {
 
         if (this.gameRules.getBoolean(GameRule.DO_TILE_DROPS)) {
             
-            if (!isSilkTouch && player != null && (player.isSurvival() || setBlockDestroy) && dropExp > 0 && drops.length != 0) {
+            if (!isSilkTouch && (mustDrop || player != null && (player.isSurvival() || setBlockDestroy)) && dropExp > 0 && drops.length != 0) {
                 this.dropExpOrb(vector.add(0.5, 0.5, 0.5), dropExp);
             }
 
-            if (player == null || setBlockDestroy || player.isSurvival()) {
+            if (mustDrop || player == null || setBlockDestroy || player.isSurvival()) {
                 for (Item drop : drops) {
                     if (drop.getCount() > 0) {
                         this.dropItem(vector.add(0.5, 0.5, 0.5), drop);


### PR DESCRIPTION
Fixes #113 

Adds `Block.mustSilkTouch()` and `Block.mustDrop()` to allow blocks to force the dropping behaviour when breaking.