### PR TITLE
Fixes EntityPortalEnterEvent not being fired when entering end portals

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,8 +11,11 @@ Click the link above to see the future.
 
 ### Fixes
 - [#224] Enchantment compatibility rules when merging enchanted items in an anvil
-- [#113] Behives not dropping in creative when it has bees
+- [#113] Beehives not dropping in creative when it has bees
 - [#270] Replacing sugarcane's water don't break the sugarcane immediately
+- [#272] `EntityPortalEnterEvent` not being fired when entering end portals
+- [#279] `BlockEndPortal` missing collision bounding box
+- [#279] `Entity.checkBlockCollision()`'s over scaffolding logic outdated
 
 ### Added
 - [#227] PlayerJumpEvent called when jump packets are received.
@@ -27,6 +30,7 @@ Click the link above to see the future.
 - [#123] Adds and register the banner pattern items
 - [#276] `Block.afterRemoval()` called automatically when the block is replaced using any `Level.setBlock()`
 - [#277] `Block.mustSilkTouch()` and `Block.mustDrop()` to allow blocks to force the dropping behaviour when being broken
+- [#279] `Entity.isInEndPortal()` for public usage
 
 ### Changed
 - [#227] Sugar canes now fires BlockGrowEvent when growing naturally.
@@ -306,8 +310,10 @@ Fixes several anvil issues.
 [#267]: https://github.com/GameModsBR/PowerNukkit/issues/267
 [#268]: https://github.com/GameModsBR/PowerNukkit/pull/268
 [#270]: https://github.com/GameModsBR/PowerNukkit/issues/270
+[#272]: https://github.com/GameModsBR/PowerNukkit/issues/272
 [#273]: https://github.com/GameModsBR/PowerNukkit/pull/273
 [#274]: https://github.com/GameModsBR/PowerNukkit/pull/274
 [#275]: https://github.com/GameModsBR/PowerNukkit/pull/275
 [#276]: https://github.com/GameModsBR/PowerNukkit/pull/276
 [#277]: https://github.com/GameModsBR/PowerNukkit/pull/277
+[#279]: https://github.com/GameModsBR/PowerNukkit/pull/279

--- a/src/main/java/cn/nukkit/api/PowerNukkitOnly.java
+++ b/src/main/java/cn/nukkit/api/PowerNukkitOnly.java
@@ -13,4 +13,5 @@ import java.lang.annotation.*;
 @Inherited
 @Documented
 public @interface PowerNukkitOnly {
+    String value() default "";
 }

--- a/src/main/java/cn/nukkit/block/BlockEndPortal.java
+++ b/src/main/java/cn/nukkit/block/BlockEndPortal.java
@@ -1,5 +1,7 @@
 package cn.nukkit.block;
 
+import cn.nukkit.api.PowerNukkitOnly;
+import cn.nukkit.api.Since;
 import cn.nukkit.item.Item;
 import cn.nukkit.item.ItemBlock;
 import cn.nukkit.math.AxisAlignedBB;
@@ -55,6 +57,8 @@ public class BlockEndPortal extends BlockFlowable {
         return true;
     }
 
+    @PowerNukkitOnly("NukkitX returns null")
+    @Since("1.2.1.0-PN")
     @Override
     public AxisAlignedBB getCollisionBoundingBox() {
         return this;

--- a/src/main/java/cn/nukkit/block/BlockEndPortal.java
+++ b/src/main/java/cn/nukkit/block/BlockEndPortal.java
@@ -2,6 +2,7 @@ package cn.nukkit.block;
 
 import cn.nukkit.item.Item;
 import cn.nukkit.item.ItemBlock;
+import cn.nukkit.math.AxisAlignedBB;
 import cn.nukkit.utils.BlockColor;
 
 public class BlockEndPortal extends BlockFlowable {
@@ -52,6 +53,11 @@ public class BlockEndPortal extends BlockFlowable {
     @Override
     public boolean hasEntityCollision() {
         return true;
+    }
+
+    @Override
+    public AxisAlignedBB getCollisionBoundingBox() {
+        return this;
     }
 
     @Override

--- a/src/main/java/cn/nukkit/entity/Entity.java
+++ b/src/main/java/cn/nukkit/entity/Entity.java
@@ -2523,6 +2523,12 @@ public abstract class Entity extends Location implements Metadatable {
         return false;
     }
 
+    @PowerNukkitOnly
+    @Since("1.2.1.0-PN")
+    public boolean isInEndPortal() {
+        return inEndPortal;
+    }
+
     @Override
     public boolean equals(Object obj) {
         if (obj == null) {


### PR DESCRIPTION
This PR:
* Fixes #272 `EntityPortalEnterEvent` not being fired when entering end portals
* Adds `Entity.inEndPortal` (protected) and `Entity.isInEndPortal()` (public)
* Fixes `BlockEndPortal` missing collision bounding box
* Fixes `Entity.checkBlockCollision()`'s over scaffolding logic outdated
