### PR TITLE
Fix ClassCastException while loading old chunks and some logic errors

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,7 @@ Click the link above to see the future.
 ### Fixes
 - [#326] Enchantment table not working
 - [#297] Using the hoe or shovel doesn't emit any sound
+- [#328] ClassCastException and some logic errors while processing the chunk backward compatibility method
 
 ## [1.3.0.1-PN] - 2020-07-01 ([Check the milestone](https://github.com/GameModsBR/PowerNukkit/milestone/14?closed=1))
 Improves plugin compatibility and downgrade the RakNet lib to solve a memory leak
@@ -425,3 +426,4 @@ Fixes several anvil issues.
 [#320]: https://github.com/GameModsBR/PowerNukkit/pull/320
 [#323]: https://github.com/GameModsBR/PowerNukkit/issues/323
 [#326]: https://github.com/GameModsBR/PowerNukkit/pull/326
+[#328]: https://github.com/GameModsBR/PowerNukkit/issues/326

--- a/src/main/java/cn/nukkit/level/format/ChunkSection.java
+++ b/src/main/java/cn/nukkit/level/format/ChunkSection.java
@@ -124,4 +124,10 @@ public interface ChunkSection {
     default int getContentVersion() {
         return 0;
     }
+
+    @PowerNukkitOnly("Needed for level backward compatibility")
+    @Since("1.3.0.2-PN")
+    default void setContentVersion(int contentVersion) {
+        // Does nothing
+    }
 }

--- a/src/main/java/cn/nukkit/level/format/anvil/ChunkSection.java
+++ b/src/main/java/cn/nukkit/level/format/anvil/ChunkSection.java
@@ -758,4 +758,11 @@ public class ChunkSection implements cn.nukkit.level.format.ChunkSection {
     public int getContentVersion() {
         return contentVersion;
     }
+
+    @PowerNukkitOnly("Needed for level backward compatibility")
+    @Since("1.3.0.2-PN")
+    @Override
+    public void setContentVersion(int contentVersion) {
+        this.contentVersion = contentVersion;
+    }
 }

--- a/src/main/java/cn/nukkit/level/format/generic/BaseChunk.java
+++ b/src/main/java/cn/nukkit/level/format/generic/BaseChunk.java
@@ -6,6 +6,7 @@ import cn.nukkit.api.PowerNukkitOnly;
 import cn.nukkit.api.Since;
 import cn.nukkit.block.Block;
 import cn.nukkit.block.BlockID;
+import cn.nukkit.block.BlockUnknown;
 import cn.nukkit.block.BlockWall;
 import cn.nukkit.blockentity.BlockEntity;
 import cn.nukkit.level.Level;
@@ -30,7 +31,7 @@ import java.util.Arrays;
 public abstract class BaseChunk extends BaseFullChunk implements Chunk {
     @PowerNukkitOnly("Needed for level backward compatibility")
     @Since("1.3.0.0-PN")
-    public static final int CONTENT_VERSION = 1;
+    public static final int CONTENT_VERSION = 2;
 
     protected ChunkSection[] sections;
 
@@ -43,12 +44,12 @@ public abstract class BaseChunk extends BaseFullChunk implements Chunk {
         boolean updated = false;
         for (ChunkSection section : sections) {
             int contentVersion = section.getContentVersion();
-            if (contentVersion < 1) {
+            if (contentVersion < 2) {
                 WallUpdater wallUpdater = new WallUpdater(level, section);
                 boolean sectionUpdated = walk(section, new GroupedUpdaters(
                         wallUpdater,
-                        new StemUpdater(level, section, BlockID.MELON_STEM, BlockID.MELON_BLOCK),
-                        new StemUpdater(level, section, BlockID.PUMPKIN_STEM, BlockID.PUMPKIN)
+                        contentVersion < 1? new StemUpdater(level, section, BlockID.MELON_STEM, BlockID.MELON_BLOCK) : null,
+                        contentVersion < 1? new StemUpdater(level, section, BlockID.PUMPKIN_STEM, BlockID.PUMPKIN) : null
                 ));
 
                 updated = updated || sectionUpdated;
@@ -65,6 +66,7 @@ public abstract class BaseChunk extends BaseFullChunk implements Chunk {
                     sectionUpdated = walk(section, wallUpdater);
                 }
                 
+                section.setContentVersion(2);
             }
         }
         
@@ -412,7 +414,7 @@ public abstract class BaseChunk extends BaseFullChunk implements Chunk {
     }
 
     @RequiredArgsConstructor
-    private class WallUpdater implements Updater {
+    private static class WallUpdater implements Updater {
         private final Level level;
         private final ChunkSection section;
 
@@ -422,7 +424,22 @@ public abstract class BaseChunk extends BaseFullChunk implements Chunk {
                 return false;
             }
 
-            BlockWall blockWall = (BlockWall) Block.get(blockId, meta, level, offsetX + x, offsetY + y, offsetZ + z, 0);
+            int levelX = offsetX + x;
+            int levelY = offsetY + y;
+            int levelZ = offsetZ + z;
+            Block block = Block.get(blockId, meta, level, levelX, levelY, levelZ, 0);
+            if (block instanceof BlockUnknown) {
+                // Block was on an invalid state, clearing the state but keeping the material type
+                block = Block.get(blockId, meta & 0xF, level, levelX, levelY, levelZ, 0);
+                if (block instanceof BlockUnknown) {
+                    Server.getInstance().getLogger()
+                            .warning("Failed to update the block X:"+levelX+", Y:"+levelY+", Z:"+levelZ+" at "+level
+                                    +", could not cast it to BlockWall.");
+                    return false;
+                }
+            }
+            
+            BlockWall blockWall = (BlockWall) block;
             if (blockWall.autoConfigureState()) {
                 section.setBlockData(x, y, z, 0, blockWall.getDamage());
                 return true;
@@ -433,7 +450,7 @@ public abstract class BaseChunk extends BaseFullChunk implements Chunk {
     }
 
     @RequiredArgsConstructor
-    private class StemUpdater implements Updater {
+    private static class StemUpdater implements Updater {
         private final Level level;
         private final ChunkSection section;
         private final int stemId;
@@ -463,7 +480,7 @@ public abstract class BaseChunk extends BaseFullChunk implements Chunk {
         }
     }
 
-    private class GroupedUpdaters implements Updater {
+    private static class GroupedUpdaters implements Updater {
         private final Updater[] updaters;
 
         public GroupedUpdaters(Updater... updaters) {
@@ -473,7 +490,7 @@ public abstract class BaseChunk extends BaseFullChunk implements Chunk {
         @Override
         public boolean update(int offsetX, int offsetY, int offsetZ, int x, int y, int z, int blockId, int meta) {
             for (Updater updater : updaters) {
-                if (updater.update(offsetX, offsetY, offsetZ, x, y, z, blockId, meta)) {
+                if (updater != null && updater.update(offsetX, offsetY, offsetZ, x, y, z, blockId, meta)) {
                     return true;
                 }
             }

--- a/src/main/java/cn/nukkit/level/format/generic/EmptyChunkSection.java
+++ b/src/main/java/cn/nukkit/level/format/generic/EmptyChunkSection.java
@@ -1,5 +1,7 @@
 package cn.nukkit.level.format.generic;
 
+import cn.nukkit.api.PowerNukkitOnly;
+import cn.nukkit.api.Since;
 import cn.nukkit.block.Block;
 import cn.nukkit.level.format.ChunkSection;
 import cn.nukkit.nbt.tag.CompoundTag;
@@ -231,5 +233,21 @@ public class EmptyChunkSection implements ChunkSection {
     @Override
     public EmptyChunkSection copy() {
         return this;
+    }
+
+    @PowerNukkitOnly
+    @Since("1.3.0.2-PN")
+    @Override
+    public int getContentVersion() {
+        return BaseChunk.CONTENT_VERSION;
+    }
+
+    @PowerNukkitOnly
+    @Since("1.3.0.2-PN")
+    @Override
+    public void setContentVersion(int contentVersion) {
+        if (contentVersion != getContentVersion()) {
+            throw new ChunkException("Tried to modify an empty Chunk");
+        }
     }
 }

--- a/src/test/java/cn/nukkit/level/format/generic/BaseChunkTest.java
+++ b/src/test/java/cn/nukkit/level/format/generic/BaseChunkTest.java
@@ -1,0 +1,93 @@
+package cn.nukkit.level.format.generic;
+
+import cn.nukkit.block.Block;
+import cn.nukkit.block.BlockID;
+import cn.nukkit.block.BlockWall;
+import cn.nukkit.level.Level;
+import cn.nukkit.level.format.ChunkSection;
+import cn.nukkit.level.format.anvil.Anvil;
+import cn.nukkit.math.BlockFace;
+import org.junit.jupiter.api.BeforeAll;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.Answers;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.mockito.Mockito.doReturn;
+import static org.mockito.Mockito.mock;
+
+@ExtendWith(MockitoExtension.class)
+class BaseChunkTest {
+    
+    @Mock
+    Anvil anvil;
+    
+    @Mock(answer = Answers.CALLS_REAL_METHODS)
+    BaseChunk chunk;
+    
+    @BeforeAll
+    static void setupEnvironment() {
+        Block.init();
+    }
+    
+    @BeforeEach
+    void setup() {
+        chunk.sections = new ChunkSection[16];
+        System.arraycopy(EmptyChunkSection.EMPTY, 0, chunk.sections, 0, 16);
+        chunk.setProvider(anvil);
+        chunk.providerClass = Anvil.class;
+    }
+    
+    @Test
+    void backwardCompatibilityUpdate2InvalidWalls() {
+        int wallType = BlockWall.WallType.DIORITE.ordinal();
+        int x = 3, y = 4, z = 5, invalid = 0b11_0000 | wallType;
+        chunk.setBlock(x, y, z, BlockID.COBBLE_WALL, invalid);
+        chunk.setBlock(x, y+1, z, BlockID.COBBLE_WALL, wallType);
+        
+        chunk.setBlock(x+1, y, z, BlockID.COBBLE_WALL, wallType);
+        chunk.setBlock(x+1, y+1, z, BlockID.COBBLE_WALL, wallType);
+
+        ChunkSection section = chunk.getSection(y >> 4);
+        section.setContentVersion(1);
+        
+        assertEquals(BlockID.COBBLE_WALL, chunk.getBlockId(x, y, z));
+        assertEquals(invalid, chunk.getBlockData(x, y, z));
+        assertEquals(1, section.getContentVersion());
+        
+        Level level = mock(Level.class, Answers.CALLS_REAL_METHODS);
+        doReturn(chunk).when(level).getChunk(x >> 4, z >> 4);
+        
+        chunk.backwardCompatibilityUpdate(level);
+        
+        assertEquals(BaseChunk.CONTENT_VERSION, section.getContentVersion());
+        assertEquals(BlockID.COBBLE_WALL, chunk.getBlockId(x, y, z));
+        assertEquals(BlockID.COBBLE_WALL, chunk.getBlockId(x, y+1, z));
+        
+        assertEquals(BlockID.COBBLE_WALL, chunk.getBlockId(x+1, y, z));
+        assertEquals(BlockID.COBBLE_WALL, chunk.getBlockId(x+1, y+1, z));
+
+        BlockWall wall = new BlockWall(wallType);
+        wall.setWallPost(true);
+        wall.setConnection(BlockFace.EAST, BlockWall.WallConnectionType.TALL);
+        assertEquals(wall.getDamage(), chunk.getBlockData(x, y, z));
+        
+        wall.setWallPost(true);
+        wall.clearConnections();
+        wall.setConnection(BlockFace.EAST, BlockWall.WallConnectionType.SHORT);
+        assertEquals(wall.getDamage(), chunk.getBlockData(x, y+1, z));
+        
+        wall.setWallPost(true);
+        wall.clearConnections();
+        wall.setConnection(BlockFace.WEST, BlockWall.WallConnectionType.TALL);
+        assertEquals(wall.getDamage(), chunk.getBlockData(x+1, y, z));
+        
+        wall.setWallPost(true);
+        wall.clearConnections();
+        wall.setConnection(BlockFace.WEST, BlockWall.WallConnectionType.SHORT);
+        assertEquals(wall.getDamage(), chunk.getBlockData(x+1, y+1, z));
+    }
+}


### PR DESCRIPTION
* Fixes #328 ClassCastException when the loading chunk has invalid wall states
* Bumps the content version to 2 to trigger a new wall update
* Enhance chunk loading performance (empty chunks will not be checked anymore)
* Update the content version number right after the update, so plugins will get the correct value