### PR TITLE
Fixes Piston Bugs (GlobalBlockPalette + sticky piston not pulling other sticky piston)

### DIFF
--- a/src/main/java/cn/nukkit/block/BlockPistonBase.java
+++ b/src/main/java/cn/nukkit/block/BlockPistonBase.java
@@ -228,7 +228,7 @@ public abstract class BlockPistonBase extends BlockSolidMeta implements Faceable
                                 .putInt("id", newBlock.getId()) //only for nukkit purpose
                                 .putInt("meta", newBlock.getDamage()) //only for nukkit purpose
                                 .putShort("val", newBlock.getDamage())
-                                .putString("name", newBlock.getName())
+                                .putString("name", GlobalBlockPalette.getName(newBlock.getId()))
                         );
 
                 if (blockEntity != null && !(blockEntity instanceof BlockEntityMovingBlock)) {

--- a/src/main/java/cn/nukkit/block/BlockPistonBase.java
+++ b/src/main/java/cn/nukkit/block/BlockPistonBase.java
@@ -228,7 +228,7 @@ public abstract class BlockPistonBase extends BlockSolidMeta implements Faceable
                                 .putInt("id", newBlock.getId()) //only for nukkit purpose
                                 .putInt("meta", newBlock.getDamage()) //only for nukkit purpose
                                 .putShort("val", newBlock.getDamage())
-                                .putString("name", GlobalBlockPalette.getName(newBlock.getId()))
+                                .putString("name", newBlock.getName())
                         );
 
                 if (blockEntity != null && !(blockEntity instanceof BlockEntityMovingBlock)) {

--- a/src/main/java/cn/nukkit/blockentity/BlockEntityPistonArm.java
+++ b/src/main/java/cn/nukkit/blockentity/BlockEntityPistonArm.java
@@ -191,8 +191,9 @@ public class BlockEntityPistonArm extends BlockEntitySpawnable {
                 }
             }
 
-            if (!extending && this.level.getBlock(getSide(facing)).getId() == (sticky? BlockID.PISTON_HEAD_STICKY : BlockID.PISTON_HEAD)) {
-                this.level.setBlock(getSide(facing), new BlockAir());
+            if (!extending) {
+                if (this.level.getBlock(getSide(facing)).getId() == (sticky? BlockID.PISTON_HEAD_STICKY : BlockID.PISTON_HEAD))
+                    this.level.setBlock(getSide(facing), new BlockAir());
                 this.movable = true;
             }
 

--- a/src/main/java/cn/nukkit/level/GlobalBlockPalette.java
+++ b/src/main/java/cn/nukkit/level/GlobalBlockPalette.java
@@ -94,6 +94,7 @@ public class GlobalBlockPalette {
             int firstMeta = firstState.getInt("val");
             register(firstId, firstMeta, runtimeId);
             stringToLegacyId.put(name, firstId);
+            legacyIdToString.put(firstId, name);
 
             for (CompoundTag legacyState : legacyStates) {
                 int newBlockId = legacyState.getInt("id");


### PR DESCRIPTION
Exception was thrown:
```
2020-07-07 17:47:21.504 [Application-Thread] ERROR - Welt "world" konnte nicht getickt werden: java.lang.IllegalArgumentException: Empty string not allowed
	at cn.nukkit.nbt.tag.StringTag.<init>(StringTag.java:19)
	at cn.nukkit.nbt.tag.CompoundTag.putString(CompoundTag.java:99)
	at cn.nukkit.block.BlockPistonBase.doMove(BlockPistonBase.java:231)
	at cn.nukkit.block.BlockPistonBase.checkState(BlockPistonBase.java:150)
	at cn.nukkit.block.BlockPistonBase.onUpdate(BlockPistonBase.java:120)
	at cn.nukkit.level.Level.updateAroundRedstone(Level.java:1257)
	at cn.nukkit.block.BlockRedstoneWire.calculateCurrentChanges(BlockRedstoneWire.java:155)
	at cn.nukkit.block.BlockRedstoneWire.updateSurroundingRedstone(BlockRedstoneWire.java:95)
	at cn.nukkit.block.BlockRedstoneWire.onUpdate(BlockRedstoneWire.java:231)
	at cn.nukkit.level.Level.updateAroundRedstone(Level.java:1257)
	at cn.nukkit.block.BlockRedstoneTorch.onBreak(BlockRedstoneTorch.java:90)
	at cn.nukkit.level.Level.useBreakOn(Level.java:2139)
	at cn.nukkit.level.Level.useBreakOn(Level.java:1999)
	at cn.nukkit.level.Level.useBreakOn(Level.java:1994)
	at cn.nukkit.level.Level.useBreakOn(Level.java:1990)
	at cn.nukkit.level.Level.useBreakOn(Level.java:1986)
	at cn.nukkit.level.Level.useBreakOn(Level.java:1982)
	at cn.nukkit.level.Level.useBreakOn(Level.java:1978)
	at cn.nukkit.block.BlockTorch.onUpdate(BlockTorch.java:56)
	at cn.nukkit.block.BlockRedstoneTorch.onUpdate(BlockRedstoneTorch.java:98)
	at cn.nukkit.level.Level.doTick(Level.java:848)
	at cn.nukkit.Server.checkTickUpdates(Server.java:1108)
	at cn.nukkit.Server.tick(Server.java:1190)
	at cn.nukkit.Server.tickProcessor(Server.java:962)
	at cn.nukkit.Server.start(Server.java:930)
	at cn.nukkit.Server.<init>(Server.java:588)
	at cn.nukkit.Nukkit.main(Nukkit.java:120)
	at sun.reflect.NativeMethodAccessorImpl.invoke0(Native Method)
	at sun.reflect.NativeMethodAccessorImpl.invoke(NativeMethodAccessorImpl.java:62)
	at sun.reflect.DelegatingMethodAccessorImpl.invoke(DelegatingMethodAccessorImpl.java:43)
	at java.lang.reflect.Method.invoke(Method.java:498)
	at de.dytanic.cloudnet.wrapper.Wrapper.lambda$startApplication$5(Wrapper.java:532)
	at java.lang.Thread.run(Thread.java:748)
```